### PR TITLE
First commit Adding Preanalysis scripts

### DIFF
--- a/.myconf.json
+++ b/.myconf.json
@@ -1,0 +1,26 @@
+{
+	"Emedgene":
+		{
+			"username":"XXX",
+			"password":"YYY",
+			"endpoint":"https://chusaintejustine.emedgene.com"
+		},
+	"Phenotips":
+		{
+			"auth":"Basic XXX",
+			"secret":"YYY",
+			"endpoint":"https://chusj.phenotips.com"
+		},
+	"GeneYX":
+		{
+			"server": "https://analysis.geneyx.com",
+			"apiUserId": "XXX",
+			"apiUserKey": "YYY"
+		},
+	"Paths":
+		{
+			"run_path": "/home/felixant/projects/ctb-rallard/COMMUN/PacBioData/",
+			"ref_maps": "/home/felixant/scratch/MINIWDL/HiFi-human-WGS-WDL/GRCh38.ref_map.v2p0p0.tsv",
+			"sample_sheet_path": "/home/felixant/scratch/MINIWDL/SampleSheet/"
+		}
+}

--- a/Preanalysis/Emedgene.py
+++ b/Preanalysis/Emedgene.py
@@ -1,0 +1,150 @@
+import requests
+import os,sys
+import logging
+import subprocess
+import json
+from configurator import Config
+
+class Emedgene:
+    """
+    Return object for interacting with Emedgene's API
+    """
+    def __init__(self, config_file=os.path.expanduser(".myconf.json")):
+        """
+        Load settings from config_file, if provided. Define instance vars to
+        provide more readable access to settings in dict "configs".
+        """
+        configs          = Config.from_path(config_file)
+        self.username    = configs.Emedgene.username
+        self.password    = configs.Emedgene.password
+        self.prag_server = configs.Emedgene.endpoint
+
+        self.pheno_auth  = configs.Phenotips.auth
+        self.pheno_secret= configs.Phenotips.secret
+        self.pheno_url   = configs.Phenotips.endpoint
+
+
+    def authenticate(self):
+        """
+        Returns an authorization token.
+        N.B. The Authorization header expires after 8H, after that, requests
+        will return an error code 403. To resolve, re-do the Login procedure to
+        get a new token.
+        """
+        # TODO: Add different domain servers
+        url      = f"{self.prag_server}/api/auth/api_login/"
+        payload  = f'{{"username": "{self.username}", "password": "{self.password}"}}'
+        headers  = {'Content-Type': 'application/json'}
+        response = requests.request("POST", url, headers=headers, data=payload).json()
+        if "Authorization" in response.keys():
+            return response["Authorization"]
+        else:
+            logging.warning("Emedgene authentication failed:")
+            print(response)
+            sys.exit(1)
+
+    def get_emg_id(self, sample):
+        """
+        Returns EMG identifier for Sample
+        - `sample`: Sample Names (ex.: GMXXXXX, 24-XXXX-T1, MO-24-XXXXX...)
+        - Returns : [str] ex.: EMGXXXXXXX, None (not found) or HTTPErrorCode
+        """
+        # TODO: Add different domain servers
+        url = f"{self.prag_server}/api/sample/?query={sample}&sampleType=fastq"
+        resp = requests.get(url, headers={'Authorization': self.authenticate()})
+        if resp.status_code == 200:
+            if resp.json()['total'] == 1:
+                return resp.json()['hits'][0]['note']
+            elif resp.json()['total'] == 0:
+                return ""
+            else:
+                logging.warning(f"More than one Emedgene case found: {resp.json()['total']}")
+                print(f"Returning the latest case involving sample {sample}: {resp.json()['hits'][-1]['note']}")
+
+                return resp.json()['hits'][-1]['note']
+        elif resp.status_code == 401 or resp.status_code == 403:
+            logging.warning(f"Unauthorized: please authenticate yourself")
+            return resp.status_code
+        else:
+            logging.warning(f"While fetching EMG ID, got the HTTP Error Code: [{resp.status_code}]\n{resp.text}")
+            return resp.status_code
+
+
+    def get_case_json(self, sample):
+        """
+        Returns the full json document for a case query, or the HTTP error code
+        - `sample`: Case name on Emedgene, ex.: EMGXXXXXX
+        - Returns : requests json object, None (not found) or HTTPErrorCode
+        """
+        url = f"{self.prag_server}/api/test/{sample}/"
+        resp = requests.get(url, headers={'Authorization': self.authenticate()})
+        if resp.status_code == 200:
+            return resp.json()
+        elif resp.status_code == 401 or resp.status_code == 403:
+            logging.warning(f"Unauthorized: please authenticate yourself")
+            return resp.status_code
+        else:
+            logging.warning(f"While fetching Case JSON, got the HTTP Error Code: [{resp.status_code}]\n{resp.text}")
+            return resp.status_code
+
+    def get_pheno_id(self, sample="", json_file=""):
+        """
+        Returns pheno identifier for Case
+        - `json_file`: If file is given, we can extract the name from it. Not necessary if sample is given
+        - `sample`: Case name (ex.: EMGXXXXXXX,...). Not necessary if json_file is provided
+        - Returns : [str] ex.: P0000XXX.., None (not found) or HTTPErrorCode
+        """
+        #Generally, this will be because an error code was received
+        if isinstance(json_file,int):
+            logging.warning(f"Error code received instead of json file: {json_file}")
+            return json_file
+
+        if len(sample)==0 and len(json_file)==0:
+            logging.warning(f"Either sample name or json file needed to extract pheno_id")
+        #Get json_file using sample name
+        elif len(json_file)==0:
+            json_file = self.get_case_json(sample)
+        #Get the notes from the json file
+        if "notes" in json_file.keys():
+            notes=json_file['notes']
+            #We expect a format of pheno ID starting with P00...
+            if notes[0:3]=="P00" and len(notes)==8:
+                return notes
+            else:
+                start = notes.find("P0")
+                end = notes.find("\n",start)
+                corrected = notes[start:end]
+                if len(corrected) == 8:
+                    return corrected
+                else:
+                    logging.warning(f"pheno_id appears to be of a different format:{notes}")
+                    return ""
+        else:
+            with open('error.json','w') as fp:
+                json.dump(json_file,fp,indent=4)
+            logging.warning(f"Pheno ID could not be found in json response. See error.json")
+
+
+    def phenotips_import_HPO_request(self,pheno_id):
+        """
+        Returns a string containing the phenotype HPO terms of a patient
+        - `pheno_id`: String of the Phenotips identifier ex.: P0000XXX... usually obtained from Emedgene
+        - Returns : str HP:00XXXXX,HP:0000XXX,...
+        """
+        url=f"{self.pheno_url}/rest/patients/{pheno_id}"
+        headers = {
+            "accept": "application/json",
+            "authorization": self.pheno_auth,
+            "X-Gene42-Secret": self.pheno_secret
+        }
+        response = requests.get(url, headers=headers)
+        data=response.json()
+
+        #Parse the list for observed phenotypes (reject non observed ones)
+        hpo_list=[]
+        for terms in data["features"]:
+            if terms["observed"] =='yes':
+                hpo_list.append(terms["id"])
+
+        return((",").join(hpo_list).replace('\'',""))
+

--- a/Preanalysis/Sample.py
+++ b/Preanalysis/Sample.py
@@ -1,0 +1,171 @@
+import sys,os
+from pathlib import Path
+import subprocess
+import logging
+import glob
+import json
+from Emedgene import Emedgene
+from configurator import Config
+
+class Sample:
+	"""
+	Sample object for patients. Eventually will be separated into Case Class and Sample Class
+	"""
+	def __init__(self, run_id, well,name="", config_file=os.path.expanduser(".myconf.json")):
+		self.run_id		=	run_id #ie r84196_20250224_170647
+		configs         = 	Config.from_path(config_file)
+		
+		self.refmaps_path	=	configs.Paths.ref_maps #This is required when writing the samplesheet
+		self.samplesheet_directory = configs.Paths.sample_sheet_path 
+		self.runs_path	=	configs.Paths.run_path
+		self.well		=	well
+		self.sample_path=	self.runs_path + f"{run_id}/{well}"
+		self.bam_path	=	self.find_bam_path()
+		self.barcode	=	self.bam_path.split("/")[-1].split("bc")[-1].removesuffix(".bam")
+
+		#Sometimes, the name from sequencing is not compatible with the Emedgene name, so it must be given manually.
+		#For example, we receive GMXXXX_redo or GMXXXX_new, while the Emedgene name should be GMXXXX 
+		if len(name) != 0:
+			self.name	=	name
+		else:
+			self.name	=	self.find_name()
+
+		self.emg_case_id	=	Emedgene(config_file=config_file).get_emg_id(self.name)
+			
+		#Does the patient belong to a trio, duo, or a singleton? Alse gender, family role and Affected status
+		#if isinstance(self.emg_case_json,int):
+		if self.emg_case_id == "":
+			#If we get an int (error code) on Emedgene, we suppose it is likely a validation case, always singleton
+			self.case_status = {"Status": "Singleton", "Role":"proband", "Gender":"null", "Affected": True}
+			self.phenotypes = ""
+		else:
+			self.emg_case_json	=	Emedgene(config_file=config_file).get_case_json(self.emg_case_id)
+			self.case_status =	self.find_status()
+
+			#TODO: Make class for Phenotips
+			self.pheno_case_id	=	Emedgene(config_file=config_file).get_pheno_id(json_file=(self.emg_case_json))
+			if self.case_status["Affected"]:
+				self.phenotypes		=	Emedgene(config_file=config_file).phenotips_import_HPO_request(self.pheno_case_id)
+			else:
+				self.phenotypes		=	""
+
+	def find_bam_path(self):
+		"""
+		Obtain the path for the BAM file of the sample. The name varies based on the time of sequencing
+		Returns: Str (File path)
+		"""
+		bam_path = glob.glob(self.sample_path + "/hifi_reads/*bc*.bam")
+
+		if len(bam_path) != 0 and os.path.isfile(bam_path[0]):
+			return bam_path[0]
+		else: 
+			logging.warning("Could not find BAM path")
+			sys.exit(1)
+
+
+	def find_name(self):
+		"""
+		Obtain the sample name from its directory. The name can be extracted from a file in the pb_format folder.
+		Returns: Str (name) or error
+		"""
+		grep_command = f"grep -o \"BioSample Name=\".*\"\" {self.sample_path}/pb_formats/*_s*.hifi_reads.bc*.consensusreadset.xml | cut -f2 -d'\"' | tr -d '\n'"
+		grep_result = subprocess.run(grep_command, shell=True, capture_output=True, text=True)
+		return grep_result.stdout
+
+	def find_status(self):
+		"""
+		Obtain the status [Singleton, Duo, Trio] of the Sample.
+		Also returns the role of Sample [Proband, father, mother], gender and affected status
+		Requires the Emedgene json case
+		Returns: Dict ({Status: [Singleton, Duo, Trio, Unknown],Role: [Proband, father, mother,"Unknown"], Gender: [Male,Female, null], Affected: [True, False,None]})
+		"""
+		json_file = self.emg_case_json
+		if "patients" in json_file.keys():
+			family_members = json_file["patients"]
+			number_in_case = len(family_members)
+			match number_in_case:
+				case 1: status = "Singleton"
+				case 2: status = "Duo"
+				case 3: status = "Trio"
+				case 4: 
+					if "other" in family_members.keys() and len(family_members["other"]) == 0:
+						status = "Trio"
+					else:
+						status = "Unknown"
+
+				case _: status = "Unknown"
+			
+			role = "Unknown"
+			gender = "null"
+			affected = None
+
+			for member in family_members.keys():
+				if member == "other":
+					continue
+				if (type(family_members[member]) is dict) and ("fastq_sample" in family_members[member]):
+					if member == "proband":
+						proband_name = family_members[member]["fastq_sample"]
+					if family_members[member]["fastq_sample"] == self.name:
+						if role == "Unknown":
+							role = member
+							gender = family_members[member]["gender"]
+							
+							pheno_list = family_members[member]["phenotypes"][0]
+							#We take a look at the phenotypes to know if parent is affected
+							#The actual phenotype list will be obtained from Phenotips (more up to date)
+							if "name" in pheno_list.keys() and pheno_list["name"] == "Healthy":
+								affected = False
+							else:
+								affected = True
+						else:
+							logging.warning(f"{self.name} was assigned roles more than once, check proper trio")
+				else:
+					logging.warning(f"The format of sample {self.name} does not correspond to expected format. See {self.name}_error.json")
+					with open(f"{self.name}_error.json",'w') as fw:
+						json.dump(json_file, fw, indent=4)
+					sys.exit(1)
+
+			if (role == "father" and gender == "Female") or (role == "mother" and gender == "Male"):
+				logging.warning(f"Error, got role {role} and gender {gender} for patient {self.name}")
+			if role == "Unknown" or gender =="null" or status == "Unknown":
+				logging.warning(f"Patient status, role or gender could not be extracted from JSON file for patient {self.name}")
+				print(f"Please see file {self.name}_error.json for more info")
+				with open(f"{self.name}_error.json",'w') as fp:
+					json.dump(json_file,fp,indent=4)
+
+			if role == "father" or role == "mother":
+				role += f" of {proband_name}"
+				if affected:
+					logging.warning(f"Be aware: Parent is affected")
+
+			return {"Status": status, "Role": role, "Gender": gender, "Affected": affected}
+		else:
+			logging.warning(f"Patient {self.name} Emedgene JSON does not seem to contain patient info.")
+			print(f"Please see file {self.name}_error.json for more info")
+			with open(f"{self.name}_error.json",'w') as fp:
+				json.dump(json_file,fp,indent=4)
+			return {"Status": "Unknown", "Role":"Unknown", "Gender":"null","Affected": None}
+		
+	def write_singleton_samplesheet(self):
+		"""
+		Writes a json samplesheet in given directory
+		This samplesheet will be used by the Pacbi WGS WDL
+		the naming convention is: {run_id}_{well}_{sample_name}.json
+		"""
+		sample_dict={"humanwgs_singleton.sample_id": self.name,\
+			"humanwgs_singleton.sex": (self.case_status["Gender"]),\
+  			"humanwgs_singleton.hifi_reads": [self.bam_path],\
+			"humanwgs_singleton.phenotypes": self.phenotypes,\
+  			"humanwgs_singleton.ref_map_file": self.refmaps_path,\
+  			"humanwgs_singleton.backend": "HPC"}
+		
+		sample_file= f"{self.samplesheet_directory}/{self.run_id}_{self.well}_{self.name}.json"
+		print(f"Writing samplesheet to {sample_file}")
+		with open(sample_file, 'w') as fw:
+			json.dump(sample_dict, fw, indent=4)
+
+		
+
+
+	def __str__(self):
+		return (f"{self.name};{self.well};{self.barcode};{self.run_id};{self.case_status['Gender']};{self.case_status['Status']};{self.case_status['Role']};{self.phenotypes}")

--- a/Preanalysis/getHPOtermsFromList.py
+++ b/Preanalysis/getHPOtermsFromList.py
@@ -1,0 +1,43 @@
+import sys,os
+from pathlib import Path
+import subprocess
+import logging
+import glob
+import json
+from Emedgene import Emedgene
+
+"""
+Simple script relying on the Emedgene class to retrieve the HPO terms from Phenotips
+As argument, give a file containing names of the sample to retrieve on different lines, ex:
+GMXXXX
+GMYYYY
+...
+The HPO terms will be written in file 'returnHPO.txt'
+"""
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python script.py <sample_name_list>")
+        sys.exit(1)
+    with open(sys.argv[1]) as f:
+        nameList = f.read().splitlines()
+    print(nameList)
+    hpoList=[]
+    print("Retrieving HPO terms for each provided sample:")
+    for name in nameList:
+        print("-----------")
+        print(f"Name :{name}")
+        emg_id=Emedgene().get_emg_id(name)
+        if not ("EMG" in emg_id):
+            logging.warning(f"{name} not found on Emedgene")
+            hpoList.append("None")
+            continue
+        print("emg output:",emg_id)
+        pheno_id=Emedgene().get_pheno_id(sample=emg_id)
+        print("pheno ID:",pheno_id)
+        hpo=Emedgene().phenotips_import_HPO_request(pheno_id)
+        hpo=hpo.replace(",",";")
+        hpoList.append(hpo)
+    print("Find the line-by-line list of HPO terms in 'returnHPO.txt'")
+    with open("returnHPO.txt",'w') as fo:
+        for term in hpoList: fo.write(f"{term}\n")

--- a/Preanalysis/singletonSampleSheet.py
+++ b/Preanalysis/singletonSampleSheet.py
@@ -1,0 +1,57 @@
+import sys,os
+import json
+import subprocess
+from Sample import Sample
+from pathlib import Path
+from configurator import Config
+
+"""
+Generate the WDL samplesheet for each sample in the given run name.
+Give the run name (ie r84196_20250210_150130) as argument and a config file, optionally
+the run folder must be present in the run_path specified in the config file (see ../.myconf.json for an example)
+"""
+if __name__ == "__main__":
+	if len(sys.argv) < 2:
+			print("Usage: python singletonSampleSheet.py <run_name> <config_file>(optional)")
+			sys.exit(1)
+
+	#The configuration file can be provided, optionally
+	if len(sys.argv) == 3:
+		config_file = sys.argv[2]
+	else:
+		config_file = "../.my_config.json"
+
+	#The paths specific to your Narval configuration should be in the Paths section of the configs
+	configs  = Config.from_path(config_file)
+	run_path = configs.Paths.run_path
+	sample_sheet_path = configs.Paths.sample_sheet_path
+
+	run_name=sys.argv[1]
+	run_folder = Path(run_path + run_name)
+	#For our run, each sample is contained in a "well" folder (ex 1_A01, 1_B01...)
+	directory_list = [f for f in run_folder.resolve().glob('*') if not f.is_file()]
+	sample_list=[]
+
+	for well_folder in directory_list:
+		#The sample name is contained in this metadata file, in the pb_format folder
+		grep_command = f"grep -o \"BioSample Name=\".*\"\" {well_folder}/pb_formats/*_s*.hifi_reads.bc*.consensusreadset.xml | cut -f2 -d'\"' | tr -d '\n'"
+		grep_result = subprocess.run(grep_command, shell=True, capture_output=True, text=True)
+		given_name = grep_result.stdout
+		well = str(well_folder).split("/")[-1]
+		sample = Sample(run_name,well,given_name,config_file=config_file)
+		sample_list.append(sample)
+		sample.write_singleton_samplesheet()
+
+	#Print the samples sorted by well (1_A01, 1_B01...)
+	sorted_list = sorted(sample_list,key=lambda x: x.well.lower())
+	for sample in sorted_list: print(sample)
+
+	#Write the list of sample name for this run and the path to their samplesheet
+	#Avoid expanding on an already existing list
+	if os.path.exists(f"{sample_sheet_path}/{run_name}_samples"):
+		os.remove(f"{sample_sheet_path}/{run_name}_samples")
+	for sample in sorted_list:
+		with open(f"{sample_sheet_path}/{run_name}_samples",'a') as fw:
+			fw.write(f"{sample.name},{sample.run_id}_{sample.well}_{sample.name}.json\n")
+
+


### PR DESCRIPTION
Includes the Sample and Emedgene classes, and two scripts that uses these classes.
-singletonSampleSheet.py takes a run name and retrieves information about all the samples included in that run. 
Will also write a samplesheet for each sample, and print sample metadata obtained through the API calls performed by the Sample and Emedgene classes. 
-getHPOtermsfromList.py is a basic script that will take a file containing a list of sample names and print a second file containing the HPO terms for each sample if they could be retrieved from Emedgene and Phenotips.
Also includes an example config file .myconf.json

I've tested these scripts on Narval, with several runs. 
I tested that the correct information was retrieved from each platform, and various edge-cases involving the format of data on these platforms. 

I will start on a README soon, and continue fleshing out the Preanalysis scripts, with the "Postanalysis" section coming soon.