### PR TITLE
Allow gender to be recognized with caps and bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ validation_merged_list.tsv
 .myconf.json
 mySampleList.txt
 *.pyc
+testSingleSamples.csv

--- a/Preanalysis/Emedgene.py
+++ b/Preanalysis/Emedgene.py
@@ -141,9 +141,12 @@ class Emedgene:
 
         #Parse the list for observed phenotypes (reject non observed ones)
         hpo_list=[]
-        for terms in data["features"]:
-            if terms["observed"] =='yes':
-                hpo_list.append(terms["id"])
+        if "features" in data.keys():
+            for terms in data["features"]:
+                if terms["observed"] =='yes':
+                    hpo_list.append(terms["id"])
+        else:
+            logging.warning(f"Features could not be found on Phenotips for sample {pheno_id}")
 
         return((",").join(hpo_list).replace('\'',""))
 

--- a/Preanalysis/Sample.py
+++ b/Preanalysis/Sample.py
@@ -171,7 +171,7 @@ class Sample:
 		the naming convention is: {run_id}_{well}_{sample_name}.json
 		"""
 		sample_dict={"humanwgs_singleton.sample_id": self.name,\
-			"humanwgs_singleton.sex": (self.case_status["Gender"]),\
+			"humanwgs_singleton.sex": (self.case_status["Gender"]).upper(),\
   			"humanwgs_singleton.hifi_reads": [self.bam_path],\
 			"humanwgs_singleton.prealigned_bams": ["pbmm2_result"],\
 			"humanwgs_singleton.phenotypes": self.phenotypes,\

--- a/mySampleList.txt
+++ b/mySampleList.txt
@@ -1,2 +1,0 @@
-GMXXX;1_A01;2093;r84196_20250207_143154;Male;Singleton;proband;HPO00001,HP0002;/home/felixant/projects/ctb-rallard/COMMUN/PacBioData/r84196_20250207_143154/1_A01/hifi_reads/m84196_250207_192712_s1.hifi_reads.bc2093.bam;True
-GMUUU;1_A01;2005;r84196_20250210_150130;Female;Duo;mother of GM242598;;/home/felixant/projects/ctb-rallard/COMMUN/PacBioData/r84196_20250210_150130/1_A01/hifi_reads/m84196_250210_150927_s1.hifi_reads.bc2005.bam;False


### PR DESCRIPTION
Gender is only recognized in WDL samplesheet if written in all caps.
Encountered a bug where the "feature" section was missing from Emedgene json file. Added condition to avoid error. 