### PR TITLE
Feat: Add getStudy.py script and fix Decodeur bug

### DIFF
--- a/Preanalysis/getSamples.py
+++ b/Preanalysis/getSamples.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 		#Special case for Decodeur Samples
 		if given_name[0:3] == "HSJ":
 			family_name = given_name[:-3]
-			if given_name[-2:] == "03":
+			if given_name[-2:] == "03" or given_name[-2:] == "04":
 				role = "proband"
 				gender = "null"
 			elif given_name[-2:] == "02":
@@ -54,7 +54,7 @@ if __name__ == "__main__":
 				role = f"father of {family_name}-03"
 				gender = "Male"
 			else:
-				print(f"Decodeur name didn't end with 01,02 or 03? Received:{given_name[-2:]}")
+				print(f"Decodeur name didn't end with 01,02,03 or 04? Received:{given_name[-2:]}")
 				sys.exit()
 
 			status = {"Status": "Decodeur", "Role":role, "Gender":gender, "Affected": False}

--- a/Preanalysis/getStudy.py
+++ b/Preanalysis/getStudy.py
@@ -1,0 +1,76 @@
+import pandas as pd
+import argparse
+import sys
+
+def get_study_info(main_csv_path, specimen_list_path):
+	"""
+	Reads a main CSV and a list of specimens, then prints selected columns
+	for the union of specimens found in both sources.
+
+	Args:
+		main_csv_path (str): Path to the main CSV file.
+		specimen_list_path (str): Path to a line-separated file of specimen names.
+	"""
+	try:
+		# Read the main CSV file
+		df = pd.read_csv(main_csv_path)
+
+		# Get the set of all specimen identifiers from the main CSV
+		all_specimens_in_csv = set(df["Identifiant : Specimen"].dropna())
+
+		# Create a DataFrame from the list of specimens to be used as the left side of the join
+		#specimens_to_find_df = pd.DataFrame(specimens_from_file, columns=["Identifiant : Specimen"])
+		specimens_to_find_df = pd.read_csv(specimen_list_path, names=["Identifiant : Specimen"], header=None)
+
+		# Perform a left join. The order of the keys from the left frame is preserved.
+		filtered_df = pd.merge(specimens_to_find_df, df, on="Identifiant : Specimen", how="left", sort=False)
+
+		# Define the columns to be printed
+		columns_to_print = [
+			"Identifiant : Specimen",
+			"Identifiant : probant",
+			"Identifiant père",
+			"Identifiant mère",
+			"Commentaires",
+			"Cohorte"
+		]
+
+		# Select and print the required columns to stdout
+		result_df = filtered_df[columns_to_print]
+		result_df.to_csv(sys.stdout, index=False)
+		print("------Only cohorts------:")
+		only_cohort = filtered_df["Cohorte"]
+		print(f"Total specimens in list file: {specimens_to_find_df.shape[0]}")
+
+		print(f"Lines in filtered list: {only_cohort.shape[0]}")
+		only_cohort.to_csv(sys.stdout, index=False)
+
+	except FileNotFoundError as e:
+		print(f"Error: File not found - {e}", file=sys.stderr)
+		sys.exit(1)
+	except KeyError as e:
+		print(f"Error: Column not found in CSV - {e}. Please check the CSV header.", file=sys.stderr)
+		sys.exit(1)
+	except Exception as e:
+		print(f"An unexpected error occurred: {e}", file=sys.stderr)
+		sys.exit(1)
+
+if __name__ == "__main__":
+	parser = argparse.ArgumentParser(
+		prog = 'getStudy.py',
+		usage = "python3 %(prog)s [-s lineSeparated_id_list] [-p pragmatiq_csv ]",	
+		description="Extracts study information for a given list of specimens."
+	)
+	parser.add_argument(
+		"-s",help="Path to a file containing a line-separated list of identifier for which you need the study",
+		required=True
+	)
+	parser.add_argument(
+		"-p",help="Path to a pragmatiq csv downloaded from the Sharepoint",
+		required=True
+	)
+
+	args = parser.parse_args()
+	main_csv_file = args.p
+	specimen_list = args.s
+	get_study_info(main_csv_file, specimen_list)


### PR DESCRIPTION
getStudy.py uses a line-separated list of identifiers and a pragmatiq list csv downloaded from the sharepoint. Prints the cohort of each provided sample ID