### PR TITLE
Hotfix rsync errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ## [Unreleased]
 
+## 2026-07-14: hotfix-rsyncErrors
+
+### Fixed
+
+- Corrects the use of robot nodes Needed to change the way "clusters" are defined in config to be more generic (i.e narval.alliancecan.ca instead of Narval)
+- Fixed a logic check that falsely made interactive sending always active
+
 ## 2026-07-13: Docs-README_Separation
 
 ### Changed

--- a/Postanalysis/postprocessPart1.sh
+++ b/Postanalysis/postprocessPart1.sh
@@ -238,36 +238,36 @@ function apptainerGet() {
 #Gathers QC data for all samples
 function buildQCData() {
 	local stat_file="$directory/_LAST/out/stats_file/$family_id.stats.txt"
-	local upstream_folder=$(cd "$directory"/_LAST/call-upstream-"$2"-* ; pwd)
-	local bam_reads=$(grep "$1" "$stat_file" | cut -f2)
-	local map_reads=$(grep "$1" "$stat_file" | cut -f8)
-	local mean_cov=$(grep "$1" "$stat_file" | cut -f12)
-	local index=$( expr "$2" + 1 )
-	local bam_file=$(grep 'hifi_reads.bc' "$samplesheet" | sed "${index}q;d" | cut -d'"' -f2)
-	local bam_directory=$(dirname $(dirname $bam_file)) #/.../1_X01
-	local failed_reads=$(grep -w '<Q20 Reads' /"$bam_directory"/statistics/m*.ccs_report.txt | cut -d: -f2 | cut -d' ' -f2 | sed "s/,//g")
-	local num_snp=$(grep "$1" "$stat_file" | cut -f22)
-	local ratio_hethom=$(grep "$1" "$stat_file" | cut -f24)
-	local num_het=$(grep -w '^PSC' "$directory/_LAST/out/small_variant_stats/$2/$1.GRCh38.small_variants.vcf.stats.txt" | cut -f6)
-	local num_hom=$(grep -w '^PSC' "$directory/_LAST/out/small_variant_stats/$2/$1.GRCh38.small_variants.vcf.stats.txt" | cut -f5)
-	local total_var=$(tail -n 1 "$directory/_LAST/out/phase_stats/$2/$1.GRCh38.hiphase.stats.tsv" | cut -d$'\t' -f3)
+	local upstream_folder; upstream_folder=$(cd "$directory"/_LAST/call-upstream-"$2"-* ; pwd)
+	local bam_reads; bam_reads=$(grep "$1" "$stat_file" | cut -f2)
+	local map_reads; map_reads=$(grep "$1" "$stat_file" | cut -f8)
+	local mean_cov; mean_cov=$(grep "$1" "$stat_file" | cut -f12)
+	local index; index=$( expr "$2" + 1 )
+	local bam_file; bam_file=$(grep 'hifi_reads.bc' "$samplesheet" | sed "${index}q;d" | cut -d'"' -f2)
+	local bam_directory; bam_directory=$(dirname "$(dirname $bam_file)") #/.../1_X01
+	local failed_reads; failed_reads=$(grep -w '<Q20 Reads' /"$bam_directory"/statistics/m*.ccs_report.txt | cut -d: -f2 | cut -d' ' -f2 | sed "s/,//g")
+	local num_snp; num_snp=$(grep "$1" "$stat_file" | cut -f22)
+	local ratio_hethom; ratio_hethom=$(grep "$1" "$stat_file" | cut -f24)
+	local num_het; num_het=$(grep -w '^PSC' "$directory/_LAST/out/small_variant_stats/$2/$1.GRCh38.small_variants.vcf.stats.txt" | cut -f6)
+	local num_hom; num_hom=$(grep -w '^PSC' "$directory/_LAST/out/small_variant_stats/$2/$1.GRCh38.small_variants.vcf.stats.txt" | cut -f5)
+	local total_var; total_var=$(tail -n 1 "$directory/_LAST/out/phase_stats/$2/$1.GRCh38.hiphase.stats.tsv" | cut -d$'\t' -f3)
 	local snv_VCF="$upstream_folder/out/small_variant_vcf/$1.GRCh38.small_variants.vcf.gz"
 	local snv_index="$upstream_folder/out/small_variant_vcf_index/$1.GRCh38.small_variants.vcf.gz.tbi"
-	local snpY=$(bcftools view -H -r chrY -f PASS "$snv_VCF##idx##$snv_index" | wc -l)
-	local snpX=$(bcftools view -H -r chrX -f PASS "$snv_VCF##idx##$snv_index" | wc -l)
-	local ratio_xy=$(echo "scale=2;$snpX/$snpY" | bc | sed "s/^\./0\./g")
+	local snpY; snpY=$(bcftools view -H -r chrY -f PASS "$snv_VCF##idx##$snv_index" | wc -l)
+	local snpX; snpX=$(bcftools view -H -r chrX -f PASS "$snv_VCF##idx##$snv_index" | wc -l)
+	local ratio_xy; ratio_xy=$(echo "scale=2;$snpX/$snpY" | bc | sed "s/^\./0\./g")
 
 	local index2=($(($index+1)))
-	local mosdepth_dir=$(dirname $(readlink -f $(grep -m 1 -A 3 "humanwgs_family.mosdepth_region_bed" $output_file | sed "${index2}q;d" | cut -d'"' -f2)))
+	local mosdepth_dir; mosdepth_dir=$(dirname $(readlink -f $(grep -m 1 -A 3 "humanwgs_family.mosdepth_region_bed" $output_file | sed "${index2}q;d" | cut -d'"' -f2)))
 	if [ -f "$mosdepth_dir/thresholdsTable.tsv" ]; then	
-		local ratio5X=$(tail -n 1 "$mosdepth_dir/thresholdsTable.tsv" | cut -f1)
-		local per5X=$(echo "scale=2;$ratio5X*100" | bc | sed "s/^\./0\./g")
+		local ratio5X; ratio5X=$(tail -n 1 "$mosdepth_dir/thresholdsTable.tsv" | cut -f1)
+		local per5X; per5X=$(echo "scale=2;$ratio5X*100" | bc | sed "s/^\./0\./g")
 		local message5X="\"Percent5x\": $per5X,"$'\n'$'\t'
-		local ratio20X=$(tail -n 1 "$mosdepth_dir/thresholdsTable.tsv" | cut -f2)
-		local per20X=$(echo "scale=2;$ratio20X*100" | bc | sed "s/^\./0\./g")
+		local ratio20X; ratio20X=$(tail -n 1 "$mosdepth_dir/thresholdsTable.tsv" | cut -f2)
+		local per20X; per20X=$(echo "scale=2;$ratio20X*100" | bc | sed "s/^\./0\./g")
 		local message20X="\"Percent20x\": $per20X,"$'\n'$'\t'
-		local ratio50X=$(tail -n 1 "$mosdepth_dir/thresholdsTable.tsv" | cut -f3)
-		local per50X=$(echo "scale=2;$ratio50X*100" | bc | sed "s/^\./0\./g")
+		local ratio50X; ratio50X=$(tail -n 1 "$mosdepth_dir/thresholdsTable.tsv" | cut -f3)
+		local per50X; per50X=$(echo "scale=2;$ratio50X*100" | bc | sed "s/^\./0\./g")
 		local message50X="\"Percent50x\": $per50X,"$'\n'$'\t'
 	else
 		local message5X=""
@@ -804,14 +804,16 @@ if [ "$include_cleanup" == true ] || [ "$run_all" == true ]; then
 		echo "Skipping rsync of symlinks (already completed successfully)"
 	else
 		echo "Sending symlinks from $directory to $USER@$cluster:$destination_path/$family_id"
-		if [ ! -n "$identity_line" ] &&   ; then
+		if [ -n "$identity_line" ]; then
+			echo "identity file not found, proceding interactively"
 			find "$directory" -type l -printf '%P\n' | \
 				rsync -rl --files-from=- "$directory" \
 				"$USER@$cluster:$destination_path/$family_id"
 		else
+			echo "identity file found, using it for automation"
 			find "$directory" -type l -printf '%P\n' | \
 				rsync -rl -e "ssh -i $identity_file" --files-from=- "$directory" \
-				"$USER@$cluster:$destination_path/$family_id"
+				"$USER@robot.$cluster:$destination_path/$family_id"
 		fi
 		record_status "rsync_symlinks" "DONE"
 	fi

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ The config file follows this format. See `configTemplate.json` for a template. T
 		},
 	"Transfers":
 		{
-			"source_cluster": "Rorqual",
+			"source_cluster": "rorqual.alliancecan.ca",
 			"source_run_path": "/home/felixant/links/projects/rrg-rallard/shared/PacBioDataRorqual/SequencerData",
 			"source_endpoint": "Globus UUID",
 			"source_collection": "Globus UUID",
-			"working_cluster": "Fir",
+			"working_cluster": "fir.alliancecan.ca",
 			"working_endpoint": "Globus UUID",
 			"working_collection": "Globus UUID",
 			"identity_file": "/home/felixant/.ssh/FirInteractive",
-			"destination_cluster": "Narval",
+			"destination_cluster": "narval.alliancecan.ca",
 			"destination_path": "/home/felixant/projects/ctb-rallard/COMMUN/PacBioData/OutputFamilies/",
 			"destination_endpoint": "Globus UUID",
 			"destination_collection": "Globus UUID"

--- a/configTemplate.json
+++ b/configTemplate.json
@@ -29,15 +29,15 @@
 		},
 	"Transfers":
 		{
-			"source_cluster": "Rorqual",
+			"source_cluster": "rorqual.alliancecan.ca",
 			"source_run_path": "/home/felixant/links/projects/rrg-rallard/shared/PacBioDataRorqual/SequencerData",
 			"source_endpoint": "Globus UUID",
 			"source_collection": "Globus UUID",
-			"working_cluster": "Fir",
+			"working_cluster": "fir.alliancecan.ca",
 			"working_endpoint": "Globus UUID",
 			"working_collection": "Globus UUID",
 			"identity_file": "/home/felixant/.ssh/FirInteractive",
-			"destination_cluster": "Narval",
+			"destination_cluster": "narval.alliancecan.ca",
 			"destination_path": "/home/felixant/projects/ctb-rallard/COMMUN/PacBioData/OutputFamilies/",
 			"destination_endpoint": "Globus UUID",
 			"destination_collection": "Globus UUID"


### PR DESCRIPTION
- Corrects the use of robot nodes Needed to change the way "clusters" are defined in config to be more generic (i.e narval.alliancecan.ca instead of Narval)
- Fixed a logic check that falsely made interactive sending always active