### PR TITLE
Feat: rclone setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ validation_merged_list.tsv
 mySampleList.txt
 *.pyc
 testSingleSamples.csv
+local_get_geneYXList.sh
+local_send_excel.sh
+.nextflow.log*
+Postanalysis/*log*
+Postanalysis/.nextflow/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ## [Unreleased]
 
+## 2026-07-20: Feat_rlone_setup
+
+### Added
+
+- Adds the `rclone_send.slurm` script, called from the `outputs_Json.sh` script, which is itself called from `postprocessPart1.sh`. It reads the bucket destination from config in Rclone:s3_bam_storage and sends the methylation/haplotagged bam to the bucket with rclone. This can take a couple of hours.
+- Added a "Rclone" section to the Postanalysis Readme, giving instructions in how setting up the config.
+
+
 ## 2026-07-14: hotfix-rsyncErrors
 
 ### Fixed

--- a/Postanalysis/README.md
+++ b/Postanalysis/README.md
@@ -11,6 +11,63 @@ Most steps are interactively orchestrated by `postprocessPart1.sh`, which submit
 
 ---
 
+## Rclone transfers
+
+### decodeur-pacbio
+
+We make use of rclone to access cloud resources related to Postanalysis. 
+The first cloud resources is the one where we store the haplotagged BAM (analysis output). Everyday at 3am URLs to this cloud are generated and sent to GeneYX. This first cloud is described in the **s3_bam_storage** in [config](../README.md#config). By default it is named decodeur-pacbio 
+
+```
+>rclone config
+>n (new account)
+>decodeur-pacbio (name)
+>4 (S3 Storage)
+>3 (Ceph Provider)
+>Enter
+>[access_key_id]
+>[secret_access_key]
+>Enter
+>https://objets.juno.calculquebec.ca/ (endpoint)
+>Enter x 5... (Leave blank until done)
+```
+
+You can test the rclone config with:
+```
+>rclone ls decodeur-pacbio:decodeur-pacbio/S3-Storage/test_monarch_01
+```
+
+The path to samples is "decodeur-pacbio/S3-Storage/["family_id"]/["proband"/"mother"/"father"]
+It contains the haplotagged bams and the cpg_pileup files. 
+
+---
+
+The second cloud resource hosts short reads analysis results. We need it to compare variants obtained from long reads analysis to the short reads GVCFs. This second cloud is described in the **short_reads_depot** in [config](../README.md#config). By default it is named staging_juno
+
+```
+>rclone config
+>n (new account)
+>staging_juno (name)
+>4 (S3 Storage)
+>7 (Minio Provider)
+>Enter
+>[access_key_id]
+>[secret_access_key]
+>Enter
+>https://objets.juno.calculquebec.ca (endpoint)
+>Enter x 5... (Leave blank until done)
+```
+You can test the rclone config with:
+```
+rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
+```
+
+	"Rclone":
+		{
+			"short_reads_depot":"staging_juno:/pragmatiq-staging-sd4h/data",
+			"s3_bam_storage":"decodeur-pacbio:decodeur-pacbio/S3-Storage"
+		}
+
 ## Scripts
 
 - **postprocessPart1.sh**

--- a/Postanalysis/outputs_Json.sh
+++ b/Postanalysis/outputs_Json.sh
@@ -53,7 +53,7 @@ if [ -f $samplesheet_dir/$family_id.txt ]; then
 	family_sampleSheet="$samplesheet_dir/$family_id.txt"
 else
 	echo "Could not find samplesheet '$family_id.txt' in $samplesheet_dir"
-python3 Preanalysis/getSamples.py -r r84196_20251107_134606	exit
+	exit
 fi
 
 outputs_file="$directory/_LAST/outputs.json"

--- a/Postanalysis/outputs_Json.sh
+++ b/Postanalysis/outputs_Json.sh
@@ -21,9 +21,7 @@ usage() { echo "Usage: $0 [-i <familyID>] [-d <directory to clean>] [-c <optiona
 config_file="$(dirname $0)/../.myconf.json"
 while getopts ":i:d:c:" o; do
     case "${o}" in
-        i)
-            family_id=${OPTARG}
-            ;;
+        i)	family_id=${OPTARG}	;;
         d)
             directory=${OPTARG}
 			if [ ! -d "$directory" ]; then
@@ -31,12 +29,8 @@ while getopts ":i:d:c:" o; do
 				exit
 			fi
             ;;
-		c)
-			config_file=${OPTARG}
-			;;
-		*)
-            usage
-            ;;
+		c)	config_file=${OPTARG}	;;
+		*)	usage	;;
     esac
 done
 
@@ -120,3 +114,12 @@ s3_destination="$HOME/projects/ctb-rallard/COMMUN/PacBioData/S3-Storage/"
 echo "Sending S3-Storage to Narval: $destination_path/$family_id"
 rsync -rl $s3_local/$family_id "NarvalInteractiveRobot:$s3_destination"
 echo "Rsync Complete"
+
+REMOTE_BASE_PREFIX=$(jq -r '.Rclone.s3_bam_storage' "$config_file")
+rclone_log="$directory/rclone_${family_id}_$(date +'%Y-%m-%d_%H-%M-%S').log"
+echo "Running Rclone send to $REMOTE_BASE_PREFIX in background (log: $rclone_log)"
+nohup rclone copy -L "$s3_destination/$family_id" "$REMOTE_BASE_PREFIX:decodeur-pacbio/S3-Storage/$family_id" \
+	>"$rclone_log" 2>&1 &
+rclone_pid=$!
+disown
+echo "Rclone running in background (PID $rclone_pid)"

--- a/Postanalysis/outputs_Json.sh
+++ b/Postanalysis/outputs_Json.sh
@@ -47,12 +47,13 @@ touch cleanupReport.txt
 
 samplesheet_dir=$(jq -r ".Paths.sample_sheet_path" $config_file)
 s3_local=$(jq -r ".Paths.s3_folder" $config_file)
+s3_fir="${s3_local}_fir"
 
 if [ -f $samplesheet_dir/$family_id.txt ]; then
 	family_sampleSheet="$samplesheet_dir/$family_id.txt"
 else
 	echo "Could not find samplesheet '$family_id.txt' in $samplesheet_dir"
-	exit
+python3 Preanalysis/getSamples.py -r r84196_20251107_134606	exit
 fi
 
 outputs_file="$directory/_LAST/outputs.json"
@@ -68,7 +69,8 @@ my_dirname=$(basename "$directory")
 local_absolute_path_prefix=${tmp%/$my_dirname/*}/$my_dirname
 echo "Updating paths in $outputs_file to point from $local_absolute_path_prefix to $destination_absolute_path"
 sed -i.bak2 "s,$local_absolute_path_prefix,$destination_absolute_path,g" "$outputs_file"
-
+outputs_file_backup=${outputs_file}.bak2
+sed -i "s,$destination_absolute_path,$local_absolute_path_prefix,g" "$outputs_file_backup"
 
 function updateSymlink() {
 	local index=$1 			# the key in outputs.json
@@ -77,19 +79,34 @@ function updateSymlink() {
 	local new_path=$4		# ...the relative path to the Output Folder in destination
 	local name=$5			# The individual sample name
 	local roleDestination=$6
-	local full_filepath=$(jq -r --arg index1 $index '.[$index1][]' $outputs_file | grep $name)
-	local new_filepath=${full_filepath/$old_path/$new_path}
+	local output=$7
+	local full_filepath;full_filepath=$(jq -r --arg index1 $index '.[$index1][]' $output | grep $name)
+	local new_filepath;new_filepath=${full_filepath/$old_path/$new_path}
 	ln -sf "$new_filepath" "$roleDestination/${new_filename}"
 }
 
 mkdir -p "$s3_local/$family_id"
+mkdir -p "$s3_fir/$family_id"
 tail -n +2 "$family_sampleSheet" | while read p; do
 	role=$(echo $p | cut -d: -f1)
 	name=$(echo $p | cut -d, -f1 | cut -d: -f2)
 	s3_role_destination="$s3_local/$family_id/$role"
+	s3_fir_role_destination="$s3_fir/$family_id/$role"
 	mkdir -p "$s3_role_destination"
+	mkdir -p "$s3_fir_role_destination"
 
-	# The symlink destination needs to be updated to reflect the correct path
+	# First we create the symlinks that are relevant to Fir here (without updating)
+	updateSymlink "humanwgs_family.merged_haplotagged_bam" "${name}.haplotagged.bam" "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.merged_haplotagged_bam_index" "${name}.haplotagged.bam.bai" "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.cpg_combined_bed" "${name}.GRCh38.cpg_pileup.combined.bed.gz"  "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.cpg_combined_bed_index" "${name}.GRCh38.cpg_pileup.combined.bed.gz.tbi"  "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.cpg_hap1_bed" "${name}.GRCh38.cpg_pileup.hap1.bed.gz" "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.cpg_hap1_bed_index" "${name}.GRCh38.cpg_pileup.hap1.bed.gz.tbi" "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.cpg_hap2_bed" "${name}.GRCh38.cpg_pileup.hap2.bed.gz" "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+	updateSymlink "humanwgs_family.cpg_hap2_bed_index" "${name}.GRCh38.cpg_pileup.hap2.bed.gz.tbi" "$destination_absolute_path" "$destination_absolute_path" "$name" "$s3_fir_role_destination" "$outputs_file_backup"
+
+
+	# The symlink destination needs to be updated to reflect the correct path to Narval
 	# When sending to Narval, the path should be ../../../OutputFamilies/$directory
 	# Because we want to keep relative paths to avoid user-specific absolute paths
 
@@ -98,14 +115,14 @@ tail -n +2 "$family_sampleSheet" | while read p; do
 	#This is a file to keep track of all samples and their new locations
 	echo "$role/$name/$family_id,$destination_absolute_path/" >>fullsampleSheet.csv
 
-	updateSymlink "humanwgs_family.merged_haplotagged_bam" "${name}.haplotagged.bam" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.merged_haplotagged_bam_index" "${name}.haplotagged.bam.bai" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.cpg_combined_bed" "${name}.GRCh38.cpg_pileup.combined.bed.gz"  "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.cpg_combined_bed_index" "${name}.GRCh38.cpg_pileup.combined.bed.gz.tbi"  "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.cpg_hap1_bed" "${name}.GRCh38.cpg_pileup.hap1.bed.gz" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.cpg_hap1_bed_index" "${name}.GRCh38.cpg_pileup.hap1.bed.gz.tbi" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.cpg_hap2_bed" "${name}.GRCh38.cpg_pileup.hap2.bed.gz" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
-	updateSymlink "humanwgs_family.cpg_hap2_bed_index" "${name}.GRCh38.cpg_pileup.hap2.bed.gz.tbi" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination"
+	updateSymlink "humanwgs_family.merged_haplotagged_bam" "${name}.haplotagged.bam" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.merged_haplotagged_bam_index" "${name}.haplotagged.bam.bai" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.cpg_combined_bed" "${name}.GRCh38.cpg_pileup.combined.bed.gz"  "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.cpg_combined_bed_index" "${name}.GRCh38.cpg_pileup.combined.bed.gz.tbi"  "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.cpg_hap1_bed" "${name}.GRCh38.cpg_pileup.hap1.bed.gz" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.cpg_hap1_bed_index" "${name}.GRCh38.cpg_pileup.hap1.bed.gz.tbi" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.cpg_hap2_bed" "${name}.GRCh38.cpg_pileup.hap2.bed.gz" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
+	updateSymlink "humanwgs_family.cpg_hap2_bed_index" "${name}.GRCh38.cpg_pileup.hap2.bed.gz.tbi" "$destination_absolute_path" "$new_path" "$name" "$s3_role_destination" "$outputs_file"
 done
 
 
@@ -115,11 +132,16 @@ echo "Sending S3-Storage to Narval: $destination_path/$family_id"
 rsync -rl $s3_local/$family_id "NarvalInteractiveRobot:$s3_destination"
 echo "Rsync Complete"
 
-REMOTE_BASE_PREFIX=$(jq -r '.Rclone.s3_bam_storage' "$config_file")
-rclone_log="$directory/rclone_${family_id}_$(date +'%Y-%m-%d_%H-%M-%S').log"
-echo "Running Rclone send to $REMOTE_BASE_PREFIX in background (log: $rclone_log)"
-nohup rclone copy -L "$s3_destination/$family_id" "$REMOTE_BASE_PREFIX:decodeur-pacbio/S3-Storage/$family_id" \
-	>"$rclone_log" 2>&1 &
-rclone_pid=$!
-disown
-echo "Rclone running in background (PID $rclone_pid)"
+# Send files to s3 cloud via the newly created symlinks
+REMOTE_BASE_PREFIX=$(jq -r '.Rclone.s3_bam_storage // empty' "$config_file")
+if [ -z "${REMOTE_BASE_PREFIX:-}" ]; then
+    echo "Rclone.s3_bam_storage not set in config — skipping rclone send."
+else
+    here_folder="$(cd "$(dirname "$0")" && pwd)"
+    echo "Submitting rclone send to $REMOTE_BASE_PREFIX/$family_id as a Slurm job"
+    rclone_job_id=$(sbatch --parsable -D "$directory" \
+        "$here_folder/rclone_send.slurm" \
+        -s "$s3_fir/$family_id" \
+        -d "$REMOTE_BASE_PREFIX/$family_id")
+    echo "Rclone job submitted (job_id=$rclone_job_id)"
+fi

--- a/Postanalysis/postprocessPart1.sh
+++ b/Postanalysis/postprocessPart1.sh
@@ -747,23 +747,23 @@ if [ "$include_concordance" == true ] || [ "$run_all" == true ]; then
 	cat << EOF 
 "Running the following: sbatch --parsable -J concordance_${family_id}_proband \
 -D $directory/Concordance $here_folder/run_concordance.sh \
--n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -f "$fasta_path"
+-n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -f "$fasta_path" -c "$config_file"
 EOF
 	dependency_concordance_proband="$(sbatch --parsable -J "sr-lr_${family_id}_proband_${proband_name}" \
 		-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
-		-n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
+		-n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file" -c "$config_file")"
 	echo "Concordance report for proband: $directory/Concordance/concordance_report_${proband_name}.txt" >> "$report_file"
 	log_step "SUBMITTED: concordance_${family_id}_proband (job_id=$dependency_concordance_proband)"
 	dependency_concordance_first="$(sbatch --parsable -J "sr-lr_${family_id}_${first_parent_role}_${first_parent_name}" \
 		-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
-		-n "$first_parent_name" -v "$first_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
+		-n "$first_parent_name" -v "$first_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file" -c "$config_file")"
 	echo "Concordance report for ${first_parent_role}: $directory/Concordance/concordance_report_${first_parent_name}.txt" >> "$report_file"
 	log_step "SUBMITTED: concordance_${family_id}_${first_parent_role} (job_id=$dependency_concordance_first)"
 	final_dependencies+=("$dependency_concordance_proband" "$dependency_concordance_first")
 	if [ "$mode" == "trio" ]; then
 		dependency_concordance_second="$(sbatch --parsable -J "sr-lr_${family_id}_${second_parent_role}_${second_parent_name}" \
 			-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
-			-n "$second_parent_name" -v "$second_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
+			-n "$second_parent_name" -v "$second_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file" -c "$config_file")"
 		echo "Concordance report for ${second_parent_role}: $directory/Concordance/concordance_report_${second_parent_name}.txt" >> "$report_file"
 		log_step "SUBMITTED: concordance_${family_id}_${second_parent_role} (job_id=$dependency_concordance_second)"
 		final_dependencies+=("$dependency_concordance_second")

--- a/Postanalysis/rclone_send.slurm
+++ b/Postanalysis/rclone_send.slurm
@@ -1,0 +1,50 @@
+#!/bin/bash
+#SBATCH --job-name=rclone_send
+#SBATCH --output=J-%x.%j.out
+#SBATCH --account=def-rallard
+#SBATCH --time=08:00:00
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=20G
+
+# Copies a local directory to an rclone remote, following symlinks (-L).
+# Tuned for large files (~70 GB) to a Ceph S3 backend:
+#   --transfers 2            : 2 files uploaded in parallel (large files — more would exhaust memory)
+#   --s3-chunk-size 512M     : multipart part size; fewer API round-trips for large files
+#   --s3-upload-concurrency 8: parallel chunk uploads per file (uses ~4 GB RAM per file transfer)
+#   --buffer-size 512M       : read-ahead buffer per transfer
+# Peak RAM: 2 files × (8 chunks × 512 MB + 512 MB buffer) ≈ 9 GB → 20 G requested with headroom
+#
+# Usage: sbatch rclone_send.slurm -s <source_dir> -d <destination> [-l <log_file>]
+#   -s  Source directory (local path, symlinks will be followed)
+#   -d  Rclone destination (e.g. decodeur-pacbio:decodeur-pacbio/S3-Storage/p136)
+#   -l  Optional shared log file for FAILED/SUCCESS status
+
+set -eo pipefail
+
+usage() { echo "Usage: $0 -s <source_dir> -d <destination> [-l <log_file>]" 1>&2; exit 1; }
+log_file=""
+while getopts ":s:d:l:" opt; do
+    case "${opt}" in
+        s)  source_dir="${OPTARG}" ;;
+        d)  destination="${OPTARG}" ;;
+        l)  log_file="${OPTARG}" ;;
+        :)  echo "Error: -${OPTARG} requires an argument."; usage ;;
+        *)  usage ;;
+    esac
+done
+log_step() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; [ -n "${log_file:-}" ] && echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*" >> "$log_file"; }
+trap 'rc=$?; [ $rc -ne 0 ] && [ -n "${log_file:-}" ] && echo "[$(date +%Y-%m-%dT%H:%M:%S)] FAILED: rclone_send to ${destination:-?} (rc=$rc)" >> "$log_file"' EXIT
+
+if [ -z "${source_dir:-}" ] || [ -z "${destination:-}" ]; then
+    echo "Error: -s and -d are required."
+    usage
+fi
+
+echo "Copying $source_dir → $destination"
+rclone copy -L \
+    --transfers 2 \
+    --s3-chunk-size 512M \
+    --s3-upload-concurrency 8 \
+    --buffer-size 512M \
+    "$source_dir" "$destination"
+log_step "SUCCESS: rclone_send to $destination"

--- a/Postanalysis/run_concordance.sh
+++ b/Postanalysis/run_concordance.sh
@@ -16,7 +16,6 @@
 
 set -eo pipefail
 module load bcftools gatk/4.6.1.0 python/3.11
-REMOTE_BASE_PREFIX="staging_juno:/pragmatiq-staging-sd4h/data"
 
 usage() {
     echo "Usage: $0 -n <sample_name> -v <lr_snv_vcf> -o <output_dir> -t <tools_folder> [-c <config_file>]"
@@ -30,7 +29,8 @@ lr_vcf=""
 output_dir=""
 fasta="$SCRATCH/GATK_references/Homo_sapiens_assembly38.fasta"
 log_file=""
-while getopts ":n:v:o:f:t:l:" opt; do
+config_file="$here_folder/../.myconf.json"
+while getopts ":n:v:o:f:t:l:c:" opt; do
     case "${opt}" in
         n)  sample_name="${OPTARG}" ;;
         v)  lr_vcf="${OPTARG}" ;;
@@ -40,6 +40,7 @@ while getopts ":n:v:o:f:t:l:" opt; do
             here_folder="$tools_folder/../Postanalysis/"
             ;;
         l)  log_file="${OPTARG}" ;;
+        c)  config_file="${OPTARG}" ;;
         :)  echo "Error: -${OPTARG} requires an argument."; usage ;;
         *)  usage ;;
     esac
@@ -61,6 +62,8 @@ if [ ! -f "$fasta" ]; then
     echo "Error: Fasta ref not found: $lr_vcf"
     exit 1
 fi
+
+REMOTE_BASE_PREFIX=$(jq -r '.Rclone.short_reads_depot' "$config_file")
 
 concordance_dir="$output_dir/Concordance"
 mkdir -p "$concordance_dir"

--- a/configTemplate.json
+++ b/configTemplate.json
@@ -41,5 +41,10 @@
 			"destination_path": "/home/felixant/projects/ctb-rallard/COMMUN/PacBioData/OutputFamilies/",
 			"destination_endpoint": "Globus UUID",
 			"destination_collection": "Globus UUID"
+		},
+	"Rclone":
+		{
+			"short_reads_depot":"staging_juno:/pragmatiq-staging-sd4h/data",
+			"s3_bam_storage":"decodeur-pacbio:decodeur-pacbio/S3-Storage"
 		}
 }


### PR DESCRIPTION
- Adds the `rclone_send.slurm` script, called from the `outputs_Json.sh` script, which is itself called from `postprocessPart1.sh`. It reads the bucket destination from config in Rclone:s3_bam_storage and sends the methylation/haplotagged bam to the bucket with rclone. This can take a couple of hours.
- Added a "Rclone" section to the Postanalysis Readme, giving instructions in how setting up the config.