### PR TITLE
Hotfix:Columns in the samplesheet used by Preanalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ## [Unreleased]
 
+## v1.1.0
+
+## 2026-07-23: Hotfix-HPOs_list_columns
+
+### Fixed:
+
+- Fixed the number of columns in the sample list both in `jointCallSampleSheet.py` and `getSamples.py`. Since columns are delimited by ';', the HPO must be separated by another character, ','.
+
 ## 2026-07-20: Feat_rlone_setup
 
 ### Added

--- a/Preanalysis/getSamples.py
+++ b/Preanalysis/getSamples.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 					bam_path = str(row["BAM"]),
 					status = {"Status":str(row["Status"]),"Role":str(row["Role"]),
 						"Gender":str(row["Gender"]),"Affected":row["Affected"]},
-					HPOs = str(row["HPO"]),
+					HPOs = str(row["HPO"]).replace(";",","),
 					study = row["Study"],
 					config_file = args.config)
 					if str(existing_sample_object) == str(sample):

--- a/Preanalysis/jointCallSampleSheet.py
+++ b/Preanalysis/jointCallSampleSheet.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
 		family_ids.append(args.father)
 	
 	#Find the samples from the list
-	sample_list = pd.read_csv(args.list,sep=";",names=["Name","Well","Barcode","run_id","Gender","Status","Role","HPO","BAM","Affected"])
+	sample_list = pd.read_csv(args.list,sep=";",names=["Name","Well","Barcode","run_id","Gender","Status","Role","HPO","Study","BAM","Affected"])
 	sample_list = sample_list.replace({np.nan: ""})
 	family={}
 	for sample_id in family_ids:


### PR DESCRIPTION
- Fixed the number of columns in the sample list both in `jointCallSampleSheet.py` and `getSamples.py`. Since columns are delimited by ';', the HPO must be separated by another character, ','.