### PR TITLE
Feat: adds a resource monitor script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Postanalysis/.nextflow/*
 J-*.out
 *_error.json
 *.xlsx
+Logs/*
+wdl_report_*

--- a/Analysis/README.md
+++ b/Analysis/README.md
@@ -23,6 +23,32 @@ This folder also contains a script called "exec_script.sh". It is meant to be in
 
 ---
 
+- **monitor_jobs.sh**
+  - *Usage*:
+    ```bash
+    sbatch Analysis/monitor_jobs.sh [interval_seconds] [job_name_filter]
+    ```
+  - *Goal*: Polls `squeue` at a regular interval while the WGS pipeline instance(s) run, tracking how many jobs are queued/running and how many CPUs/RAM they are allocated. Also tracks the running peak of each of those numbers, so the report log shows the highest concurrency/resource usage reached over the course of the run(s). Meant to help size future submissions against real cluster usage.
+  - *Arguments*:
+    - `interval_seconds` — how often to poll, in seconds (default `600`).
+    - `job_name_filter` — optional `squeue -n` glob/name filter to restrict polling to a subset of jobs (default: all jobs for the current user).
+  - *Outputs*: Appends a timestamped CSV row per poll to `Analysis/wdl_monitor_report.log`, plus a human-readable line to stdout/the Slurm job log. Prints a final peak summary to the log when the job is cancelled or hits its time limit.
+
+---
+
+- **seff_report.py**
+  - *Usage*:
+    ```bash
+    python3 Analysis/seff_report.py <miniwdl_run_dir> [-o OUTPUT]
+    ```
+  - *Goal*: Given a miniwdl run folder (e.g. `/home/felixant/scratch/p155`), checks whether the run completed successfully (presence of `_LAST/out`), then walks every task directory looking for `slurm-<id>.out` logs and runs `seff` on each job id. Reports status, cores, CPU time, CPU efficiency, wall-clock time, memory utilized, memory requested, and memory efficiency for every job, and flags task directories that hold more than one `slurm-*.out` file (i.e. the task was restarted) with the attempt number. Ends with a summary: job/attempt counts, restarted directories, state distribution, total CPU/wall-clock time, total memory utilized, the longest single job, and CPU/memory efficiency (average, wall-time-weighted average, min, max — excluding jobs under 1 minute of wall-clock time, since their efficiency is dominated by fixed startup overhead).
+  - *Arguments*:
+    - `run_dir` — the miniwdl run folder to inspect (positional).
+    - `-o`/`--output` — write the report to this path instead of the default `<run_dir>/resource_efficiency_report_<run_dir_basename>.log` (the report is always printed to stdout too).
+  - *Outputs*: A resource-efficiency report printed to stdout and saved next to the run folder.
+
+---
+
 ## Pipeline submodule
 
 The WGS pipeline lives in `Analysis/HiFi-human-WGS-WDL/`, included as a git submodule. The fork at [FelixAntoineLeSieur/HiFi-human-WGS-WDL](https://github.com/FelixAntoineLeSieur/HiFi-human-WGS-WDL) contains installation instructions and the Alliance-specific modifications.

--- a/Analysis/monitor_jobs.sh
+++ b/Analysis/monitor_jobs.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+#SBATCH --job-name=wdl_monitor
+#SBATCH --account=def-rallard
+#SBATCH --time=24:00:00
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=256M
+#SBATCH --output=J-%x.%j.out
+#
+# Polls squeue for the current user every INTERVAL seconds and reports:
+#   - how many jobs are in the queue (pending+running = "requested")
+#   - how many are actually running
+#   - total CPUs/RAM currently allocated to running jobs
+#   - total CPUs/RAM that would be needed if every queued job ran at once
+#   - job counts grouped by the first 10 characters of the job name
+# Also tracks the running peak of each of those numbers, so that after the
+# 3 WDL workflow instances have finished you can look at the report log and
+# see the highest concurrency/resource usage that was ever reached.
+#
+# The monitor's own job is excluded from all counts. Once it is the only
+# job left in the queue (nothing left to monitor) it prints the final peak
+# summary and exits on its own, instead of idling until --time runs out.
+#
+# NOTE: this reports requested/allocated resources as seen by squeue, not
+# measured (sstat) usage - that's what matters for sizing future submissions.
+#
+# Usage: sbatch monitor_wdl_jobs.sh [interval_seconds] [job_name_filter]
+#   interval_seconds : how often to poll (default 600 = 10 min)
+#   job_name_filter  : optional squeue -n glob/name filter, e.g. a common
+#                      prefix used by miniwdl task jobs. Default: all jobs
+#                      for the current user.
+#
+# The monitor exits when it hits the time
+# limit or is cancelled, whichever comes first.
+
+set -uo pipefail
+
+SCRIPT_DIR="/home/felixant/scratch/Ste-JustinePacbioWGS/Analysis"
+INTERVAL="${1:-600}"
+NAME_FILTER="${2:-}"
+SELF_JOB_ID="${SLURM_JOB_ID:-$$}"
+LOGFILE="$SCRIPT_DIR/wdl_monitor_report_$(date '+%Y%m%d_%H%M%S')_${SELF_JOB_ID}.log"
+
+peak_total=0
+peak_running=0
+peak_pending=0
+peak_cpus_running=0
+peak_mem_running=0
+peak_cpus_requested=0
+peak_mem_requested=0
+
+log_line() {
+	echo "$*" | tee -a "$LOGFILE"
+}
+
+print_final_summary() {
+	log_line ""
+	log_line "===== FINAL PEAK SUMMARY $(date '+%F %T') ====="
+	log_line "Peak jobs requested (pending+running): $peak_total"
+	log_line "Peak jobs running:                     $peak_running"
+	log_line "Peak jobs pending:                      $peak_pending"
+	log_line "Peak CPUs allocated to running jobs:    $peak_cpus_running"
+	log_line "Peak RAM allocated to running jobs:     ${peak_mem_running} MB"
+	log_line "Peak CPUs requested (all queued jobs):  $peak_cpus_requested"
+	log_line "Peak RAM requested (all queued jobs):   ${peak_mem_requested} MB"
+}
+
+trap 'print_final_summary; exit 0' SIGTERM SIGINT
+
+echo "timestamp,jobs_total,jobs_running,jobs_pending,cpus_running,mem_running_mb,cpus_requested,mem_requested_mb" >"$LOGFILE"
+
+echo "Starting WDL job monitor (self job id: $SELF_JOB_ID). Polling every ${INTERVAL}s. Report log: $LOGFILE"
+[ -n "$NAME_FILTER" ] && echo "Filtering jobs by name pattern: $NAME_FILTER"
+
+while true; do
+	if [ -n "$NAME_FILTER" ]; then
+		squeue_out="$(squeue -h -u "$USER" -n "$NAME_FILTER" -o "%i|%t|%C|%m|%j" 2>/dev/null)"
+	else
+		squeue_out="$(squeue -h -u "$USER" -o "%i|%t|%C|%m|%j" 2>/dev/null)"
+	fi
+	# drop the monitor's own job from every count below
+	squeue_out="$(echo "$squeue_out" | awk -F'|' -v self="$SELF_JOB_ID" '$1 != self')"
+
+	read -r jobs_total jobs_running jobs_pending cpus_running mem_running cpus_requested mem_requested <<<"$(
+		echo "$squeue_out" | awk -F'|' '
+			{
+				total++
+				cpus = $3 + 0
+				mem = $4
+				gsub(/[^0-9.]/, "", mem)
+				mem += 0
+				cpus_req += cpus
+				mem_req += mem
+				if ($2 == "R") {
+					running++
+					cpus_run += cpus
+					mem_run += mem
+				} else if ($2 == "PD") {
+					pending++
+				}
+			}
+			END {
+				print total+0, running+0, pending+0, cpus_run+0, mem_run+0, cpus_req+0, mem_req+0
+			}
+		'
+	)"
+
+	job_groups="$(
+		echo "$squeue_out" | awk -F'|' '
+			{
+				group = substr($5, 1, 10)
+				count[group]++
+				if ($2 == "R") running[group]++
+				else if ($2 == "PD") pending[group]++
+			}
+			END {
+				for (g in count) {
+					printf "%s|%d|%d|%d\n", g, count[g], running[g]+0, pending[g]+0
+				}
+			}
+		' | sort -t'|' -k2 -rn
+	)"
+
+	if [ "$jobs_total" -eq 0 ]; then
+		echo "No jobs left to monitor besides this one (self job id: $SELF_JOB_ID). Stopping."
+		print_final_summary
+		exit 0
+	fi
+
+	[ "$jobs_total" -gt "$peak_total" ] && peak_total=$jobs_total
+	[ "$jobs_running" -gt "$peak_running" ] && peak_running=$jobs_running
+	[ "$jobs_pending" -gt "$peak_pending" ] && peak_pending=$jobs_pending
+	[ "$cpus_running" -gt "$peak_cpus_running" ] && peak_cpus_running=$cpus_running
+	[ "$mem_running" -gt "$peak_mem_running" ] && peak_mem_running=$mem_running
+	[ "$cpus_requested" -gt "$peak_cpus_requested" ] && peak_cpus_requested=$cpus_requested
+	[ "$mem_requested" -gt "$peak_mem_requested" ] && peak_mem_requested=$mem_requested
+
+	timestamp="$(date '+%F %T')"
+	echo "$timestamp,$jobs_total,$jobs_running,$jobs_pending,$cpus_running,$mem_running,$cpus_requested,$mem_requested" >>"$LOGFILE"
+
+	{
+		echo "[$timestamp] Jobs: total=$jobs_total running=$jobs_running pending=$jobs_pending | Running: cpus=$cpus_running mem=${mem_running}MB | Requested(all): cpus=$cpus_requested mem=${mem_requested}MB | Peaks so far: total=$peak_total running=$peak_running cpus_running=$peak_cpus_running mem_running=${peak_mem_running}MB cpus_req=$peak_cpus_requested mem_req=${peak_mem_requested}MB"
+		echo "  Job groups (by first 10 chars of name):"
+		echo "$job_groups" | awk -F'|' '{ printf "    %-10s : %d (running=%d pending=%d)\n", $1, $2, $3, $4 }'
+	} | tee -a "$LOGFILE"
+
+	sleep "$INTERVAL"
+done

--- a/Analysis/seff_report.py
+++ b/Analysis/seff_report.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+#
+# Walks a miniwdl run folder, finds every slurm-<id>.out log left behind by
+# the workflow's task directories, and runs `seff` on each job id to report
+# its resource efficiency. Directories holding more than one slurm-*.out file
+# indicate the task was restarted (e.g. after a preemption or OOM retry) -
+# every attempt is reported, flagged as RESTARTED, and numbered by attempt.
+#
+# Usage: seff_report.py <miniwdl_run_dir> [-o OUTPUT]
+#   miniwdl_run_dir : e.g. /home/felixant/scratch/p155 (the folder containing
+#                     the "_LAST" symlink), or the resolved run dir itself.
+#   -o/--output     : write the report here instead of the default
+#                     <miniwdl_run_dir>/resource_efficiency_report_<basename>.log
+#                     (the report is always printed to stdout too).
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+SLURM_OUT_RE = re.compile(r"^slurm-(\d+)\.out$")
+
+SEFF_FIELDS = {
+    "state": re.compile(r"^State:\s*(.+)$", re.MULTILINE),
+    "cores": re.compile(r"^Cores(?: per node)?:\s*(.+)$", re.MULTILINE),
+    "cpu_time": re.compile(r"^CPU Utilized:\s*(.+)$", re.MULTILINE),
+    "cpu_eff": re.compile(r"^CPU Efficiency:\s*(.+)$", re.MULTILINE),
+    "wall_time": re.compile(r"^Job Wall-clock time:\s*(.+)$", re.MULTILINE),
+    "mem_util": re.compile(r"^Memory Utilized:\s*(.+)$", re.MULTILINE),
+    "mem_eff": re.compile(r"^Memory Efficiency:\s*(.+)$", re.MULTILINE),
+}
+
+NA = "N/A"
+
+
+def find_run_dir(root):
+    last = root / "_LAST"
+    if last.is_dir():
+        return last
+    return root
+
+
+def run_seff(job_id):
+    try:
+        result = subprocess.run(
+            ["seff", job_id], capture_output=True, text=True, timeout=30
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"error": f"seff invocation failed: {exc}"}
+
+    output = result.stdout
+    if result.returncode != 0 or not output.strip():
+        message = (output + result.stderr).strip() or f"seff exited {result.returncode}"
+        return {"error": message}
+
+    parsed = {}
+    for key, pattern in SEFF_FIELDS.items():
+        match = pattern.search(output)
+        parsed[key] = match.group(1).strip() if match else NA
+
+    parsed["state"] = re.sub(r"\s*\(exit code[^)]*\)", "", parsed["state"])
+
+    requested_match = re.search(r"of\s+([\d.]+\s*[A-Za-z]+)", parsed["mem_eff"])
+    requested_raw = requested_match.group(1) if requested_match else NA
+    parsed["mem_util"] = to_gb_str(parsed["mem_util"])
+    parsed["mem_requested"] = to_gb_str(requested_raw)
+
+    for key in ("cpu_eff", "mem_eff"):
+        pct = re.match(r"([\d.]+%)", parsed[key])
+        if pct:
+            parsed[key] = pct.group(1)
+    return parsed
+
+
+def gather(run_dir):
+    """Returns a list of task dirs, each a dict with 'dir' (relative path)
+    and 'attempts' (list of job ids, sorted oldest-first by job id)."""
+    tasks = []
+    for dirpath, _dirnames, filenames in os.walk(str(run_dir), followlinks=True):
+        job_ids = []
+        for name in filenames:
+            m = SLURM_OUT_RE.match(name)
+            if m:
+                job_ids.append(int(m.group(1)))
+        if job_ids:
+            job_ids.sort()
+            rel = str(Path(dirpath).relative_to(run_dir))
+            tasks.append({"dir": rel, "attempts": job_ids})
+    tasks.sort(key=lambda t: t["dir"])
+    return tasks
+
+
+def parse_hms(time_str):
+    """'D-HH:MM:SS' or 'HH:MM:SS' -> total seconds. Returns None if unparseable."""
+    if not time_str or time_str == NA:
+        return None
+    days = 0
+    if "-" in time_str:
+        day_part, time_str = time_str.split("-", 1)
+        try:
+            days = int(day_part)
+        except ValueError:
+            return None
+    parts = time_str.split(":")
+    try:
+        parts = [int(p) for p in parts]
+    except ValueError:
+        return None
+    while len(parts) < 3:
+        parts.insert(0, 0)
+    h, m, s = parts[-3:]
+    return days * 86400 + h * 3600 + m * 60 + s
+
+
+def format_hms(total_seconds):
+    if total_seconds is None:
+        return NA
+    total_seconds = int(round(total_seconds))
+    days, rem = divmod(total_seconds, 86400)
+    h, rem = divmod(rem, 3600)
+    m, s = divmod(rem, 60)
+    if days:
+        return f"{days}-{h:02d}:{m:02d}:{s:02d}"
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def parse_percent(eff_str):
+    if not eff_str or eff_str == NA:
+        return None
+    m = re.match(r"([\d.]+)%", eff_str.strip())
+    return float(m.group(1)) if m else None
+
+
+def parse_mem_mb(mem_str):
+    if not mem_str or mem_str == NA:
+        return None
+    m = re.match(r"([\d.]+)\s*([A-Za-z]+)", mem_str.strip())
+    if not m:
+        return None
+    value, unit = float(m.group(1)), m.group(2).upper()
+    scale = {"KB": 1 / 1024, "MB": 1, "GB": 1024, "TB": 1024 * 1024}
+    return value * scale.get(unit, 1)
+
+
+def to_gb_str(mem_str):
+    """Any 'seff'-style memory string ('35.43 MB', '1.20 GB', ...) -> 'X.XX GB'."""
+    mb = parse_mem_mb(mem_str)
+    return f"{mb / 1024:.2f} GB" if mb is not None else NA
+
+
+def parse_gb(gb_str):
+    if not gb_str or gb_str == NA:
+        return None
+    m = re.match(r"([\d.]+)\s*GB", gb_str.strip())
+    return float(m.group(1)) if m else None
+
+
+def build_report(run_dir, tasks):
+    lines = []
+    rows = []  # flat list of per-job dicts, for the summary pass
+
+    header = (
+        f"{'Directory':<55} {'Attempt':<9} {'JobID':<10} {'State':<20} "
+        f"{'Cores':<6} {'CPU Time':<11} {'CPU Eff':<9} {'Wall Time':<11} "
+        f"{'Mem Util':<10} {'Mem Req':<10} {'Mem Eff':<9}"
+    )
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for task in tasks:
+        attempts = task["attempts"]
+        restarted = len(attempts) > 1
+        for idx, job_id in enumerate(attempts, start=1):
+            info = run_seff(str(job_id))
+            if "error" in info:
+                row_display = {
+                    "state": f"ERROR: {info['error']}",
+                    "cores": NA,
+                    "cpu_time": NA,
+                    "cpu_eff": NA,
+                    "wall_time": NA,
+                    "mem_util": NA,
+                    "mem_requested": NA,
+                    "mem_eff": NA,
+                }
+            else:
+                row_display = info
+
+            attempt_label = f"{idx}/{len(attempts)}" + (" R" if restarted else "")
+            lines.append(
+                f"{task['dir']:<55} {attempt_label:<9} {job_id:<10} "
+                f"{row_display['state']:<20} {row_display['cores']:<6} "
+                f"{row_display['cpu_time']:<11} {row_display['cpu_eff']:<9} "
+                f"{row_display['wall_time']:<11} {row_display['mem_util']:<10} "
+                f"{row_display['mem_requested']:<10} {row_display['mem_eff']:<9}"
+            )
+            rows.append(
+                {
+                    "dir": task["dir"],
+                    "job_id": job_id,
+                    "restarted": restarted,
+                    **row_display,
+                }
+            )
+
+    return "\n".join(lines), rows
+
+
+def build_summary(rows):
+    lines = ["", "===== SUMMARY =====", ""]
+
+    total_jobs = len(rows)
+    task_dirs = {r["dir"] for r in rows}
+    restarted_dirs = sorted({r["dir"] for r in rows if r["restarted"]})
+    errored = [r for r in rows if str(r["state"]).startswith("ERROR")]
+
+    lines.append(f"Task directories:     {len(task_dirs)}")
+    lines.append(f"Slurm jobs (attempts): {total_jobs}")
+    lines.append(f"Restarted directories: {len(restarted_dirs)}")
+    for d in restarted_dirs:
+        n = sum(1 for r in rows if r["dir"] == d)
+        lines.append(f"  - {d} ({n} attempts)")
+    if errored:
+        lines.append(f"Jobs seff could not report on: {len(errored)}")
+
+    state_counts = Counter(r["state"] for r in rows if not str(r["state"]).startswith("ERROR"))
+    if state_counts:
+        lines.append("")
+        lines.append("Job states:")
+        for state, count in sorted(state_counts.items(), key=lambda kv: -kv[1]):
+            lines.append(f"  {state:<25} {count}")
+
+    for r in rows:
+        r["_wall_secs"] = parse_hms(r["wall_time"])
+        r["_cpu_secs"] = parse_hms(r["cpu_time"])
+        r["_cpu_eff_pct"] = parse_percent(r["cpu_eff"])
+        r["_mem_eff_pct"] = parse_percent(r["mem_eff"])
+        r["_mem_util_gb"] = parse_gb(r["mem_util"])
+
+    cpu_secs = [r["_cpu_secs"] for r in rows if r["_cpu_secs"] is not None]
+    wall_rows = [r for r in rows if r["_wall_secs"] is not None]
+    mem_gb = [r["_mem_util_gb"] for r in rows if r["_mem_util_gb"] is not None]
+
+    lines.append("")
+    if cpu_secs:
+        lines.append(f"Total CPU time (all attempts):   {format_hms(sum(cpu_secs))}")
+    if wall_rows:
+        total_wall = sum(r["_wall_secs"] for r in wall_rows)
+        longest = max(wall_rows, key=lambda r: r["_wall_secs"])
+        lines.append(f"Total wall-clock time (summed):  {format_hms(total_wall)}")
+        lines.append(
+            f"Longest single job wall-time:     {format_hms(longest['_wall_secs'])} "
+            f"({longest['dir']}, job {longest['job_id']})"
+        )
+    if mem_gb:
+        lines.append(f"Total memory utilized (summed):   {sum(mem_gb):.2f} GB")
+
+    # Efficiency stats exclude jobs under 1 minute of wall-clock time - their
+    # efficiency numbers are dominated by fixed job-startup overhead and are
+    # not representative of actual resource usage.
+    MIN_WALL_SECS = 60
+    eff_rows = [r for r in wall_rows if r["_wall_secs"] >= MIN_WALL_SECS]
+    skipped = len(wall_rows) - len(eff_rows)
+
+    lines.append("")
+    if skipped:
+        lines.append(
+            f"(excluding {skipped} job(s) under 1 minute of wall-clock time from "
+            f"the efficiency stats below)"
+        )
+
+    cpu_eff_pairs = [
+        (r["_cpu_eff_pct"], r["_wall_secs"]) for r in eff_rows if r["_cpu_eff_pct"] is not None
+    ]
+    if cpu_eff_pairs:
+        effs = [e for e, _ in cpu_eff_pairs]
+        weighted_avg = sum(e * w for e, w in cpu_eff_pairs) / sum(w for _, w in cpu_eff_pairs)
+        lines.append(
+            f"CPU efficiency:    avg {sum(effs)/len(effs):.2f}%  "
+            f"wall-time-weighted avg {weighted_avg:.2f}%  "
+            f"min {min(effs):.2f}%  max {max(effs):.2f}%"
+        )
+
+    mem_eff_pairs = [
+        (r["_mem_eff_pct"], r["_wall_secs"]) for r in eff_rows if r["_mem_eff_pct"] is not None
+    ]
+    if mem_eff_pairs:
+        effs = [e for e, _ in mem_eff_pairs]
+        weighted_avg = sum(e * w for e, w in mem_eff_pairs) / sum(w for _, w in mem_eff_pairs)
+        lines.append(
+            f"Memory efficiency: avg {sum(effs)/len(effs):.2f}%  "
+            f"wall-time-weighted avg {weighted_avg:.2f}%  "
+            f"min {min(effs):.2f}%  max {max(effs):.2f}%"
+        )
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path, help="miniwdl run folder (e.g. .../p155)")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help=(
+            "write the report to this file instead of the default "
+            "<run_dir>/resource_efficiency_report_<run_dir_basename>.log"
+        ),
+    )
+    args = parser.parse_args()
+
+    root = args.run_dir.resolve()
+    if not root.is_dir():
+        sys.exit(f"error: {root} is not a directory")
+
+    run_dir = find_run_dir(root)
+    out_dir = run_dir / "out"
+    if not out_dir.is_dir():
+        print(
+            f"warning: {run_dir}/out not found - this run does not look like it "
+            f"completed successfully. Reporting on jobs found so far anyway.",
+            file=sys.stderr,
+        )
+
+    tasks = gather(run_dir)
+    if not tasks:
+        sys.exit(f"no slurm-*.out files found under {run_dir}")
+
+    table, rows = build_report(run_dir, tasks)
+    summary = build_summary(rows)
+    full_report = f"Run directory: {run_dir}\n\n{table}\n{summary}\n"
+
+    output_path = args.output or root / f"resource_efficiency_report_{root.name}.log"
+    print(full_report)
+    output_path.write_text(full_report)
+    print(f"Report written to {output_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
  
 ## [Unreleased]
+2026-08-18: Feat_monitor_benchmark
+
+### Added
+
+- `Analysis/monitor_jobs.sh`: polls `squeue` at a regular interval while WGS pipeline instances run, logging job counts and CPU/RAM allocation (and their running peaks) to `Analysis/wdl_monitor_report.log`.
+- `Analysis/seff_report.py`: given a miniwdl run folder, checks it completed successfully (`_LAST/out` present), then runs `seff` on every `slurm-<id>.out` job under it and reports status, cores, CPU time/efficiency, wall-clock time, and memory utilized/requested/efficiency per job. Flags restarted tasks (multiple `slurm-*.out` files in the same directory) and ends with a summary (totals, longest job, and wall-time-weighted efficiency stats).
+- `Postanalysis/postprocessPart1.sh` now runs `Analysis/seff_report.py` as an interactive step (before the GeneYX send steps); it is skipped automatically (no prompt) if a `resource_efficiency_report_<familyID>.log` already exists in the run directory.
 
 ## 2026-08-18: Feat-Jasmine
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
  
 ## [Unreleased]
-2026-08-18: Feat_monitor_benchmark
+## 2026-08-18: Feat_monitor_benchmark
 
 ### Added
 

--- a/Postanalysis/README.md
+++ b/Postanalysis/README.md
@@ -72,7 +72,7 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
 
 - **postprocessPart1.sh**
   - *Usage*: `bash Postanalysis/postprocessPart1.sh -i <familyID> -g <group> [-s] [-c config]`
-  - *Goal*: Main orchestrator for post-processing. Normalizes per-sample VCFs, runs the GeneYX unified VCF step, uploads samples and the case to GeneYX, then submits Slurm jobs for Somalier, Peddy, SVTopo, Triomix (trios only), MultiQC, and per-sample SR/LR concordance checks. Optionally runs cleanup and initiates the Globus transfer to Narval.
+  - *Goal*: Main orchestrator for post-processing. Optionally runs `Analysis/seff_report.py` on the miniwdl run directory, normalizes per-sample VCFs, runs the GeneYX unified VCF step, uploads samples and the case to GeneYX, then submits Slurm jobs for Somalier, Peddy, SVTopo, Triomix (trios only), MultiQC, and per-sample SR/LR concordance checks. Optionally runs cleanup and initiates the Globus transfer to Narval.
   - *Arguments*:
     - `-i` Family or sample ID (must match a samplesheet in `sample_sheet_path`)
     - `-g` Study group: `Pragmatiq`/`prag`/`p`, `Decodeur`/`decode`/`d`, or `Validation`/`valid`/`v`
@@ -82,6 +82,7 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
     - `R-{id}_YYYY-MM-DD_HH-MM-SS_postprocess_report.txt` — timestamped log of each command's stdout/stderr
     - `status_{id}_YYYY-MM-DD_HH-MM-SS.log` — timestamped step status log (SUBMITTED / SUCCESS / FAILED per step)
     - `send_status.log` — static per-step status file for the cleanup/transfer steps; supports re-run skipping
+    - `resource_efficiency_report_{id}.log` — `seff` resource-efficiency report (see [Analysis README](../Analysis/README.md#seff_reportpy)); the step is skipped if this file already exists
 
 ---
 
@@ -160,6 +161,30 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
     - **AMBIGUOUS** (75–90 %)
     - **LIKELY DIFFERENT PATIENTS** (< 75 %)
   - *Notes*: Requires `cyvcf2` and `numpy` (available via the `Tools/ENV` virtualenv). Called automatically by `run_concordance.sh`; can also be run standalone for ad-hoc comparisons.
+
+---
+
+- **proband_allele_depth.py**
+  - *Usage*: `python3 Postanalysis/proband_allele_depth.py -t <prefix>.parental_only.tsv -o <output_prefix> --run-dir <family_run_dir>` (or `-g <proband.g.vcf.gz> [--rnc-vcf <raw_joint.vcf.gz>]` instead of `--run-dir`)
+  - *Goal*: For every "parental-only" variant reported by `filter_parents.py`, reports the proband's allele depth (ref-supporting vs. alt-supporting reads). When the proband is an explicit hom-ref call in the joint VCF, its AD is read directly from the `parental_only.tsv`. When the proband is a no-call (`./.`) in the joint VCF, the same position is looked up in the proband's own gVCF instead, since the joint VCF carries no read information for no-calls but the gVCF still does (either an actual variant record with AD, or a hom-ref reference block, in which case alt support is 0). For those no-call variants, also looks up the proband's **RNC (Reason for No Call)** in the raw GLnexus joint VCF, explaining *why* GLnexus didn't call the proband there (e.g. `II` = the proband's own gVCF simply never called anything at that site; `DD` = GLnexus's depth reconciliation across the variant's span came up short, often due to an adjacent/overlapping low-depth call — see `filter_parents.py`'s REASON column vs. this script's RNC output for a worked example).
+  - *Arguments*:
+    - `-t` / `--parental-tsv` — `parental_only.tsv` from `filter_parents.py`
+    - `-o` / `--output-prefix` — output prefix
+    - `--run-dir` — HiFi-human-WGS-WDL family run directory (the folder containing `_LAST`). Infers `--gvcf` (`_LAST/out/small_variant_gvcf/0/*.g.vcf.gz`) and `--rnc-vcf` (`_LAST/call-joint/call-glnexus/out/vcf/*.vcf.gz`) automatically — an explicit `--gvcf`/`--rnc-vcf` overrides the inferred path. **Note**: the RNC source is the raw `call-joint/call-glnexus` task output, *not* the WDL's published `_LAST/out/joint_small_variants_vcf/` — that one has already had DP/AD/GQ/PL/RNC blanked out for no-calls by the time phasing is done with it.
+    - `-g` / `--gvcf` — proband's single-sample gVCF (must be bgzip-compressed and tabix-indexed, `.tbi` alongside). Not needed if `--run-dir` is given.
+    - `--rnc-vcf` — the raw, pre-phasing GLnexus joint VCF (see note above). Optional; if neither this nor `--run-dir` is given, the RNC lookup/report is skipped.
+    - `--parental-vcf` — `parental_only.vcf.gz` from `filter_parents.py`, used to write the high-alt-support VCF subset below. Default: `--parental-tsv` with `.tsv` replaced by `.vcf.gz` (i.e. the matching file `filter_parents.py` wrote alongside the TSV).
+    - `--min-alt-fraction` — alt allele fraction threshold for flagging a variant as possibly missed in the proband (default: 0.1)
+    - `--min-depth` — total depth threshold for the same flag (default: 5)
+  - *Outputs*:
+    - `<prefix>.proband_depth.tsv` — per-variant CHROM/POS/REF/ALT, `GROUP` (`PROBAND_MISSING`/`PROBAND_REF`, from the TSV's REASON column), source of the depth call, proband/mother/father GT, ref/alt/other read depth, alt allele fraction, and `PROBAND_RNC` (`NA` for `PROBAND_REF` rows, or when no RNC source was given).
+    - `<prefix>.proband_depth_bins.tsv` — for each group, the variant count, proportion, and mean total depth in each 0.05-wide alt-allele-fraction bin.
+    - `<prefix>.proband_depth.png` — one column per group (`PROBAND_MISSING`, `PROBAND_REF`): a stacked proportion histogram of the proband's alt allele fraction (stacked by depth source for the missing group) on top, and the mean total depth per bin below. Useful for spotting parental-only calls where the proband actually shows partial read support for the variant, and for gauging whether the low-support bins are just low-depth noise.
+    - `<prefix>.high_alt_support.vcf.gz` — the subset of parental-only variants where the proband's alt allele fraction and depth both clear the `--min-alt-fraction`/`--min-depth` thresholds (default: fraction > 0.1, depth > 5), for candidates the caller may have missed in the proband. `PROBAND_REF` records are copied straight from `parental_only.vcf.gz` (already informative — the proband's AD is right there). `PROBAND_MISSING` records are rewritten to a simplified `GT:DP:AD` FORMAT with the proband's field populated from the gVCF-derived depth instead of the joint VCF's uninformative `./.`; mother/father fields are carried over unchanged, and `PROBAND_SOURCE` is added to INFO.
+    - `<prefix>.high_alt_support_genotype.tsv` — for the same high-alt-support variants, a full `MOTHER_CLASS`/`FATHER_CLASS`/`PROBAND_CLASS` cross-tab (each `HOM_REF`/`HET`/`HOM_ALT`/`MISSING`/`PARTIAL_MISSING`), from which counts like "homozygous-ALT parent but ref/missing proband call" (the strongest Mendelian-inheritance signal that the caller may have missed something) can be derived.
+    - `<prefix>.high_alt_support_rnc.tsv` — proband RNC code counts among the flagged `PROBAND_MISSING` variants (only written when `--run-dir`/`--rnc-vcf` is given).
+    - Per-group counts, the full per-bin table (count, proportion, mean depth), the high-alt-support variant count, a human-readable digest of the genotype cross-tab (proband GT class distribution; ≥1-parent-HOM_ALT and both-parents-HOM_ALT breakdowns; mean depth/alt-fraction per proband GT class), and the RNC code breakdown (with GLnexus's own header description of each code) are also printed to stdout.
+  - *Notes*: Requires `pysam` and `matplotlib` (available via the `Tools/ENV` virtualenv).
 
 ---
 

--- a/Postanalysis/postprocessPart1.sh
+++ b/Postanalysis/postprocessPart1.sh
@@ -344,7 +344,6 @@ else
 fi
 
 report_file="$directory/R-${id}_$(date +'%Y-%m-%d_%H-%M-%S')_postprocess_report.txt"
-#log_file="$directory/status_${id}_$(date +'%Y-%m-%d_%H-%M-%S').log"
 log_file="$report_file"
 echo "Report file is $report_file"
 echo "Status log: $log_file"
@@ -500,10 +499,18 @@ fi
 
 #-----Steps-----#
 
+seff_report_file="$directory/resource_efficiency_report_$(basename "$directory").log"
+
 if [ $run_all == true ]; then
 	echo "Running all steps without prompt"
 else
 	echo "Interactive mode enabled, will prompt for each step"
+	if [ -f "$seff_report_file" ]; then
+		echo "Resource efficiency report already exists at $seff_report_file, skipping prompt"
+		run_seff_report=false
+	else
+		ask_yes_no "Run seff resource-efficiency report on the miniwdl run?" run_seff_report
+	fi
 	ask_yes_no "Send to GeneYX?" send_to_geneyx
 	ask_yes_no "Send Case to GeneYX?" send_case_to_geneyx
 	ask_yes_no "Send QC info to GeneYX?" send_qc_to_geneyx
@@ -515,6 +522,18 @@ else
 	ask_yes_no "Include SR/LR concordance check?" include_concordance
 	ask_yes_no "Include cleanup and send?" include_cleanup
 
+fi
+
+#Seff resource-efficiency report step
+if [ -f "$seff_report_file" ]; then
+	echo "Resource efficiency report already exists at $seff_report_file, skipping" >> "$report_file"
+elif [ "$run_seff_report" == true ] || [ "$run_all" == true ]; then
+	echo "Generating seff resource-efficiency report for $family_id" >> "$report_file"
+	if python3 "$here_folder/../Analysis/seff_report.py" "$directory" >> "$report_file" 2>&1; then
+		log_step "DONE: seff resource-efficiency report for $family_id"
+	else
+		rc=$?; log_step "FAILED: seff resource-efficiency report for $family_id (rc=$rc)"; exit $rc
+	fi
 fi
 
 #Send to GeneYX step
@@ -741,7 +760,7 @@ if [ "$include_multiqc" == true ] || [ "$run_all" == true ]; then
 fi
 
 #SR/LR concordance step
-if [ "$include_concordance" == true ] || [ "$run_all" == true ]; then
+if [[ $group_code != "decode" && ("$include_concordance" == true || "$run_all" == true) ]] ; then
 	echo "Launching SR/LR concordance checks" >> "$report_file"
 	mkdir -p "$directory/Concordance"
 	cat << EOF 
@@ -768,6 +787,8 @@ EOF
 		log_step "SUBMITTED: concordance_${family_id}_${second_parent_role} (job_id=$dependency_concordance_second)"
 		final_dependencies+=("$dependency_concordance_second")
 	fi
+elif [[ $group_code != "decode" ]]; then
+	log_step "SKIPPED: concordance, not for decodeur cases"
 fi
 
 #Cleanup and transfer step

--- a/Postanalysis/rclone_send.slurm
+++ b/Postanalysis/rclone_send.slurm
@@ -2,8 +2,8 @@
 #SBATCH --job-name=rclone_send
 #SBATCH --output=J-%x.%j.out
 #SBATCH --account=def-rallard
-#SBATCH --time=08:00:00
-#SBATCH --cpus-per-task=8
+#SBATCH --time=12:00:00
+#SBATCH --cpus-per-task=1
 #SBATCH --mem=20G
 
 # Copies a local directory to an rclone remote, following symlinks (-L).
@@ -45,6 +45,7 @@ rclone copy -L \
     --transfers 2 \
     --s3-chunk-size 512M \
     --s3-upload-concurrency 8 \
+    --multi-thread-streams 16 \
     --buffer-size 512M \
     "$source_dir" "$destination"
 log_step "SUCCESS: rclone_send to $destination"

--- a/Postanalysis/run_concordance.sh
+++ b/Postanalysis/run_concordance.sh
@@ -3,7 +3,7 @@
 #SBATCH --output=J-%x.%j.out
 #SBATCH --account=def-rallard
 #SBATCH --mem=8G
-#SBATCH --time=02:00:00
+#SBATCH --time=05:00:00
 
 # Runs SR/LR VCF concordance for a single sample.
 # Fetches the Illumina GVCF from the staging server via rclone, then calls

--- a/Tools/requirements.txt
+++ b/Tools/requirements.txt
@@ -58,6 +58,7 @@ pygments==2.19.2+computecanada
 pygtail==0.14.0
 PyJWT==2.10.1+computecanada
 pyparsing==3.3.2+computecanada
+pysam==0.23.3+computecanada
 python_dateutil==2.9.0.post0+computecanada
 python_json_logger==4.1.0+computecanada
 pytz==2025.2+computecanada

--- a/Tools/requirements.txt
+++ b/Tools/requirements.txt
@@ -11,7 +11,6 @@ contourpy==1.3.3+computecanada
 cyvcf2==0.31.1+computecanada
 cryptography==45.0.6+computecanada
 cycler==0.12.1+computecanada
-cyvcf2==0.31.1+computecanada
 debugpy==1.8.19+computecanada
 decorator==5.2.1+computecanada
 docker==7.1.0+computecanada


### PR DESCRIPTION
seff_report.py is meant to be run during analysis to measure the number of concurrent jobs and resources requested.
monitor_jobs.sh can be run after the Analysis is complete. Will gather resource information from each requested slurm jobs. Also includes a few fixes, notably for concordance compatibility with Decodeur group.