### PR TITLE
Feature: Add jasmine methylation (re)calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ local_send_excel.sh
 .nextflow.log*
 Postanalysis/*log*
 Postanalysis/.nextflow/*
+*.log
+J-*.out
+*_error.json
+*.xlsx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ## [Unreleased]
 
+## 2026-08-18: Feat-Jasmine
+
+### Added
+
+- Added `Preanalysis/jasmine.slurm`: (re)calls 5mC methylation on a well's hifi/fail BAMs using a specified pbjasmine version. This is needed because the jasmine version used has a large influence on methylation calls (different versions use different models), and the on-instrument version does not always match the one recommended by SickKids (v2.0.0). Handles downloading/caching the requested jasmine version and, for v2.0.0, rewrites the BAM header's BINDINGKIT/SEQUENCINGKIT so SPRQ-chemistry BAMs are accepted.
+- Added `Preanalysis/run_jasmine.sh`: submits `jasmine.slurm` for every well of a given run, logging submitted job IDs to `jasmine_run_<run_id>.log`.
+
 ## v1.1.0
 
 ## 2026-07-23: Hotfix-HPOs_list_columns

--- a/Postanalysis/postprocessPart1.sh
+++ b/Postanalysis/postprocessPart1.sh
@@ -433,9 +433,9 @@ inferred_gender=$(grep -A 3 humanwgs_family.inferred_sex $output_file | sed "2q;
 # Check the first parent (usually the mother)
 first_parent_real_gender=$(grep -m2 '"sex": ' "$samplesheet" | sed -n '2p' | cut -d'"' -f4)
 first_parent_inferred_gender=$(grep -A 3 humanwgs_family.inferred_sex $output_file | sed "3q;d" | cut -d\" -f2)
-if [ "$first_parent_real_gender" == "FEMALE" ]; then
+if [ "$first_parent_real_gender" == "FEMALE" ] || [ "$first_parent_real_gender" == "Female" ]; then
 	first_parent_role="Mother"
-elif [ "$first_parent_real_gender" == "MALE" ]; then
+elif [ "$first_parent_real_gender" == "MALE" ] || [ "$first_parent_real_gender" == "Male" ]; then
 	first_parent_role="Father"
 else
 	echo "Warning: First parent's given gender is not recognized: $first_parent_real_gender"
@@ -447,9 +447,9 @@ if [ "$mode" == "trio" ]; then
 	second_parent_real_gender=$(grep -m3 '"sex": ' "$samplesheet" | sed -n '3p' | cut -d'"' -f4)
 	second_parent_inferred_gender=$(grep -A 3 humanwgs_family.inferred_sex $output_file | sed "4q;d" | cut -d\" -f2)
 
-	if [ "$second_parent_real_gender" == "MALE" ]; then
+	if [ "${second_parent_real_gender,,}" == "male" ]; then
 		second_parent_role="Father"
-	elif [ "$second_parent_real_gender" == "FEMALE" ]; then
+	elif [ "${second_parent_real_gender,,}" == "female" ]; then
 		second_parent_role="Mother"
 	else
 		echo "Warning: Second parent's given gender is not recognized: $second_parent_real_gender"
@@ -459,12 +459,12 @@ fi
 
 # Check specifically for errors in assigned and inferred genders
 genderError=false
-if [ "$first_parent_inferred_gender" != "$first_parent_real_gender" ]; then
+if [ "${first_parent_inferred_gender,,}" != "${first_parent_real_gender,,}" ]; then
 	echo "Warning: First parent's (Of assigned role $first_parent_role) inferred gender is not $first_parent_real_gender:  Got $first_parent_inferred_gender"
 	genderError=true
 fi
 
-if [ "$second_parent_inferred_gender" != "$second_parent_real_gender" ]; then
+if [ "${second_parent_inferred_gender,,}" != "${second_parent_real_gender,,}" ]; then
 	echo "Warning: Second parent's (Of assigned role $second_parent_role) inferred gender is not $second_parent_real_gender:  Got $second_parent_inferred_gender"
 	genderError=true
 fi
@@ -473,7 +473,7 @@ if [ "$real_gender" = "null" ] && [ "$inferred_gender" = "null" ];then
 	echo "Warning: gender is set to 'null'"
 	final_gender=""
 else
-	if [ "$real_gender" = "$inferred_gender" ];then
+	if [ "${real_gender,,}" = "${inferred_gender,,}" ];then
 		echo "Proband Gender confirmed to be $real_gender" >> $report_file
 		final_gender=$(echo $real_gender | cut -c1-1)
 	elif [ "$real_gender" = "null" ];then

--- a/Postanalysis/run_concordance.sh
+++ b/Postanalysis/run_concordance.sh
@@ -18,7 +18,7 @@ set -eo pipefail
 module load bcftools gatk/4.6.1.0 python/3.11
 
 usage() {
-    echo "Usage: $0 -n <sample_name> -v <lr_snv_vcf> -o <output_dir> -t <tools_folder> [-c <config_file>]"
+    echo "Usage: $0 -n <sample_name> -v <lr_snv_vcf> -f -o <output_dir> -t <tools_folder> [-c <config_file>]"
     1>&2; exit 1
 }
 
@@ -59,7 +59,7 @@ if [ ! -f "$lr_vcf" ]; then
 fi
 
 if [ ! -f "$fasta" ]; then
-    echo "Error: Fasta ref not found: $lr_vcf"
+    echo "Error: Fasta ref not found: $fasta"
     exit 1
 fi
 

--- a/Preanalysis/README.md
+++ b/Preanalysis/README.md
@@ -122,6 +122,16 @@ The getSamples.py and samplesheet scripts can also be called manually on Fir if 
 
 ---
 
+- **run_jasmine.sh**
+  - *Usage*:
+    ```bash
+    bash Preanalysis/run_jasmine.sh -r <run_id> [-t <jasmine_version>] [-c <config_file>]
+    ```
+  - *Goal*: Submits one `jasmine.slurm` job per well/cell of a given run, to (re)call 5mC methylation with a specific pbjasmine version. On-instrument methylation calls depend on the jasmine version used at sequencing time, which can differ from the version recommended for analysis, so this lets us recall methylation uniformly across a run. For each well, it locates the hifi consensusreadset XML under `pb_formats/` and passes it to `jasmine.slurm`, which does the actual model download/execution and BAM/XML rewriting (see `jasmine.slurm` header for available version tags).
+  - *Outputs*: One Slurm job submitted per well (wells without a `pb_formats` folder are skipped), and a `jasmine_run_<run_id>.log` file (written next to the script) recording `<cell_folder> job id: <job_id>` for each submission.
+
+---
+
 ## Helper modules
 
 These files are imported by the scripts above and are not meant to be called directly.

--- a/Preanalysis/getSamples.py
+++ b/Preanalysis/getSamples.py
@@ -36,8 +36,15 @@ if __name__ == "__main__":
 
 	#For each well folder, we need to retrieve the sample name from the metadata file
 	for well_folder in directory_list:
-		#The sample name is contained in this metadata file, in the pb_format folder
-		grep_command = f"grep -o \"BioSample Name=\".*\"\" {well_folder}/pb_formats/*_s*.hifi_reads.bc*.consensusreadset.xml | cut -f2 -d'\"' | tr -d '\n'"
+
+		hifi_bam_matches = list(Path(f"{well_folder}/hifi_reads").glob("*bc*.bam"))
+		if len(hifi_bam_matches) == 0:
+			sys.exit(f"Error: no *bc*.bam file found in {well_folder}/hifi_reads")
+		if len(hifi_bam_matches) > 1:
+			sys.exit(f"Error: expected exactly one *bc*.bam file in {well_folder}/hifi_reads, found {len(hifi_bam_matches)}: {[m.name for m in hifi_bam_matches]}")
+		hifi_prefix = hifi_bam_matches[0].stem
+		#The sample name is contained in this metadata file, in the pb_format folder		
+		grep_command = f"grep -o \"BioSample Name=\".*\"\" {well_folder}/pb_formats/{hifi_prefix}.consensusreadset.xml | cut -f2 -d'\"' | tr -d '\n'"
 		grep_result = subprocess.run(grep_command, shell=True, capture_output=True, text=True)
 		given_name = grep_result.stdout
 		#Special case for Decodeur Samples

--- a/Preanalysis/jasmine.slurm
+++ b/Preanalysis/jasmine.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#SBATCH --time=6:00:00
+#SBATCH --time=24:00:00
 #SBATCH --account=def-rallard
 #SBATCH --output=J-%x.%j.out
 #SBATCH --cpus-per-task=16
@@ -35,7 +35,7 @@ usage() {
 }
 JASMINE_VERSION="2.0.0"
 JASMINE_TAG="${JASMINE_TAGS[$JASMINE_VERSION]:-}"
-config_file="$SCRATCH/MINIWDL/Ste-JustinePacbioWGS/.myconf.json"
+config_file="$SCRATCH/Ste-JustinePacbioWGS/.myconf.json"
 while getopts "x:t:c:" opt; do
     case "${opt}" in
 		x)	INXML="${OPTARG}"
@@ -89,8 +89,6 @@ cp -v "$INXML" "$outxml"
 echo "INXML $(basename "$INXML")"
 echo "OUTXML $(basename "$outxml")"
 
-barcode=$(echo "$prefix" | cut -d'.' -f3)
-
 echo "Using pbjasmine version $JASMINE_VERSION (tag $JASMINE_TAG)"
 JASMINE_DIR="$tools_folder/Jasmine_$JASMINE_TAG"
 
@@ -126,10 +124,29 @@ for readType in "ConsensusReadBamFile:hifi_reads" "FailReadBamFile:fail_reads"; 
 	in_base=$(basename "$in_bam")
 	out_base="${in_base%.bam}.jasminev2.bam"
 
-	echo "Copying $in_base to scratch"
-	cp -v "$in_bam" "$SLURM_TMPDIR/$in_base"
 	ls -lah "$SLURM_TMPDIR"
 	[ -f "$in_bam.pbi" ] && cp -v "$in_bam.pbi" "$SLURM_TMPDIR/$in_base.pbi"
+	
+	# If jasmine version is 2.0.0, it will not work with SPRQ chemistry.
+	# We need to replace the BINDINGKIT and SEQUENCINGKIT in BAM header
+	# jasmine itself removes any existing MM/ML tags before inference, so no
+	# separate tag-stripping pass is needed here.
+	if [ "$JASMINE_TAG" == "2.0.0" ]; then
+		module load samtools/1.22.1
+		# Header files live in $SLURM_TMPDIR, not next to $in_bam: that source
+		# directory is shared/read-only PacBioData storage, not guaranteed writable.
+		new_header_file="$SLURM_TMPDIR/header_$(basename "$in_bam" .bam)_new.txt"
+		samtools view -H "$in_bam" | \
+			sed "s/BINDINGKIT=103-496-900;SEQUENCINGKIT=103-496-700/BINDINGKIT=102-739-100;SEQUENCINGKIT=102-118-800/" \
+			> "$new_header_file"
+		echo "Changing headers for input bam $in_base"
+		# The reheader can only be performed in-place with CRAMs, not BAMs
+		samtools reheader "$new_header_file" "$in_bam" > "$SLURM_TMPDIR/$in_base"
+	else
+		echo "Copying $in_base to scratch"
+		cp -v "$in_bam" "$SLURM_TMPDIR/$in_base"
+	fi
+	echo "Running Jasmine command:"
 	cat << EOF
 "$SLURM_TMPDIR"/jasmine \
 -j "$THREADS" \
@@ -158,3 +175,8 @@ EOF
 	rm -f "$SLURM_TMPDIR/$in_base" "$SLURM_TMPDIR/$in_base.pbi" "$SLURM_TMPDIR/$out_base" "$SLURM_TMPDIR/$out_base.pbi"
 	out_bams+=("$pbDir/$out_base")
 done
+
+# Only reached if every step above succeeded (set -e). run_jasmine.sh checks for this marker
+# to skip cells that were already successfully processed with this jasmine version.
+touch "$pbDir/.jasmine_${JASMINE_VERSION}.done"
+echo "Marked $pbDir as done for jasmine $JASMINE_VERSION"

--- a/Preanalysis/jasmine.slurm
+++ b/Preanalysis/jasmine.slurm
@@ -1,0 +1,160 @@
+#!/bin/bash
+#
+#SBATCH --time=6:00:00
+#SBATCH --account=def-rallard
+#SBATCH --output=J-%x.%j.out
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --tmp=600G
+
+set -eo pipefail
+#Argument 1 is MOVIE.bcXXXX.consensusreadset.xml
+#Argument 2 (optional) is the pbjasmine version to run, e.g. 2.4.0 - see JASMINE_TAGS below
+#for the known versions and the exact quay.io/biocontainers tag each maps to. Defaults to
+#$DEFAULT_JASMINE_VERSION if omitted - jasmine has a hard-coded list of sequencing chemistries
+#it recognizes as supported, so a BAM from newer basecaller/kit combinations may need a newer
+#version than the default (see quay.io/biocontainers/pbjasmine/tags for available tags).
+
+#YOU MUST PROVIDE THE FULL ABSOLUTE PATH
+#example call:
+#sbatch -D /home/felixant/links/projects/rrg-rallard/shared/PacBioDataRorqual/SequencerData/r84196_20251010_130733/1_B01/pb_formats jasmine.slurm -x /home/felixant/links/projects/rrg-rallard/shared/PacBioDataRorqual/SequencerData/r84196_20251010_130733/1_B01/pb_formats/m84196_251010_201413_s3.hifi_reads.bc2090.consensusreadset.xml -t 2.4.0
+declare -A JASMINE_TAGS=(
+  ["2.0.0"]="2.0.0"
+  ["2.4.0"]="2.4.0"
+  ["2.7.99"]="2.7.99"
+  ["26.1.2"]="26.1.2"
+  ["26.1.3"]="26.1.3"
+)
+
+
+: "${SLURM_TMPDIR:?SLURM_TMPDIR is not set - this script must run inside a Slurm job}"
+
+usage() {
+    echo "Usage: $0 -x <consensusreadset.xml> [-t <jasmine_version>] [-c <config_file>]" 1>&2
+    exit 1
+}
+JASMINE_VERSION="2.0.0"
+JASMINE_TAG="${JASMINE_TAGS[$JASMINE_VERSION]:-}"
+config_file="$SCRATCH/MINIWDL/Ste-JustinePacbioWGS/.myconf.json"
+while getopts "x:t:c:" opt; do
+    case "${opt}" in
+		x)	INXML="${OPTARG}"
+			if [ ! -f "$INXML" ]; then
+				echo "XML file not found"
+				usage
+			fi
+			prefix=$(basename "$INXML" .consensusreadset.xml)
+			pbDir=$(dirname "$INXML")
+			;;
+        t)  JASMINE_VERSION="${OPTARG}"
+			JASMINE_TAG="${JASMINE_TAGS[$JASMINE_VERSION]:-}"
+            ;;
+        c)  config_file="${OPTARG}" ;;
+        :)  echo "Error: -${OPTARG} requires an argument."; usage ;;
+        *)  usage ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${INXML:-}" ]; then
+	echo "Error: -x <consensusreadset.xml> is required." >&2
+	usage
+fi
+
+
+if [ -z "$JASMINE_TAG" ]; then
+  echo "Unknown pbjasmine version '$JASMINE_VERSION'. Known versions: ${!JASMINE_TAGS[*]}" >&2
+  exit 1
+fi
+
+# default value for config
+if [ ! -f "$config_file" ]; then
+	if [ -f "$(dirname "$0")/.myconf.json" ]; then
+		config_file="$(dirname "$0")/.myconf.json"
+	else
+		echo "config file not found: $config_file. You can input one with option '-c'"
+		exit 1
+	fi
+fi
+
+wgs_folder=$(jq -r '.Paths.WGS_folder' "$config_file")
+tools_folder="$wgs_folder/Tools"
+if [ ! -d "$tools_folder" ]; then
+	echo "Tools folder in run folder $wgs_folder not found, please put it in config file, under 'Path/WGS_folder'"
+	exit 1
+fi
+
+outxml="$pbDir/$prefix.jasmine.consensusreadset.xml"
+cp -v "$INXML" "$outxml"
+echo "INXML $(basename "$INXML")"
+echo "OUTXML $(basename "$outxml")"
+
+barcode=$(echo "$prefix" | cut -d'.' -f3)
+
+echo "Using pbjasmine version $JASMINE_VERSION (tag $JASMINE_TAG)"
+JASMINE_DIR="$tools_folder/Jasmine_$JASMINE_TAG"
+
+#download if necessary
+if [ ! -f "$JASMINE_DIR/jasmine" ]; then
+	mkdir -p "$JASMINE_DIR"
+	# This tag specifically is not tarred
+	if [ "$JASMINE_TAG" == "2.0.0" ]; then
+		wget -P "$JASMINE_DIR" https://github.com/PacificBiosciences/jasmine/releases/download/v2.0.0/jasmine
+	else
+		wget -P "$JASMINE_DIR" https://github.com/PacificBiosciences/jasmine/releases/download/v${JASMINE_TAG}/jasmine.tar.xz
+		tar -xf "$JASMINE_DIR/jasmine.tar.xz" -C "$JASMINE_DIR"
+	fi
+fi
+
+cp -v "$JASMINE_DIR/jasmine" "$SLURM_TMPDIR/jasmine"
+THREADS=${SLURM_CPUS_PER_TASK:-3}
+chmod +x "$SLURM_TMPDIR/jasmine"
+# Jasmine calls 5mC in CpG motifs. This only works for BAMs with kinetics data.
+"$SLURM_TMPDIR/jasmine" --version
+
+out_bams=()
+for readType in "ConsensusReadBamFile:hifi_reads" "FailReadBamFile:fail_reads"; do
+	metaType=${readType%%:*}
+	dirName=${readType##*:}
+
+	# Extract relative path in xml
+	rel=$(grep -oP "MetaType=\"PacBio\.ConsensusReadFile\.${metaType}\"[^>]*ResourceId=\"\K[^\"]+\.bam" "$INXML")
+	echo "Readtype: $readType"
+	echo "Rel: $rel"
+	#unassigned_rel=${rel/$barcode/unassigned}
+	in_bam=$(realpath -m "$pbDir/$rel") #$(realpath -m "$pbDir/$unassigned_rel")
+	in_base=$(basename "$in_bam")
+	out_base="${in_base%.bam}.jasminev2.bam"
+
+	echo "Copying $in_base to scratch"
+	cp -v "$in_bam" "$SLURM_TMPDIR/$in_base"
+	ls -lah "$SLURM_TMPDIR"
+	[ -f "$in_bam.pbi" ] && cp -v "$in_bam.pbi" "$SLURM_TMPDIR/$in_base.pbi"
+	cat << EOF
+"$SLURM_TMPDIR"/jasmine \
+-j "$THREADS" \
+--log-level DEBUG \
+--log-file "$pbDir/jasmine.$dirName.log" \
+"$SLURM_TMPDIR/$in_base" \
+"$SLURM_TMPDIR/$out_base"
+EOF
+	"$SLURM_TMPDIR"/jasmine \
+		-j "$THREADS" \
+		--log-level DEBUG \
+		--log-file "$pbDir/jasmine.$dirName.log" \
+		"$SLURM_TMPDIR/$in_base" \
+		"$SLURM_TMPDIR/$out_base"
+
+	echo "Copying results back for $dirName"
+	#mv -v "$SLURM_TMPDIR/jasmine.$dirName.log" "$pbDir/jasmine.$dirName.log"
+	cp -v "$SLURM_TMPDIR/$out_base" "$pbDir/$out_base"
+	[ -f "$SLURM_TMPDIR/$out_base.pbi" ] && cp -v "$SLURM_TMPDIR/$out_base.pbi" "$pbDir/$out_base.pbi"
+
+	# Point the output XML at the new local (same-directory) jasmine BAM instead of the old
+	# ../$dirName/ path, so it no longer resolves outside of $pbDir.
+	sed -i "s,ResourceId=\"\.\./${dirName}/${in_base}\",ResourceId=\"./${out_base}\",g; s,ResourceId=\"\.\./${dirName}/${in_base}\.pbi\",ResourceId=\"./${out_base}\.pbi\",g" "$outxml"
+
+	# Free scratch space before the next read type
+	rm -f "$SLURM_TMPDIR/$in_base" "$SLURM_TMPDIR/$in_base.pbi" "$SLURM_TMPDIR/$out_base" "$SLURM_TMPDIR/$out_base.pbi"
+	out_bams+=("$pbDir/$out_base")
+done

--- a/Preanalysis/run_jasmine.sh
+++ b/Preanalysis/run_jasmine.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# This is meant to run the jasmine.slurm sbatch script on ALL samples in a run.
+# For each well/cell folder in the run, it locates the hifi consensusreadset XML
+# under pb_formats/ and submits one jasmine.slurm job for it, logging the
+# resulting job ID so submissions can be tracked/followed up on later.
+set -eo pipefail
+
+
+usage() {
+    echo "Usage: $0 [-r <run_id> ] [-t <jasmine_version>] [-c <config_file>]" 1>&2
+    exit 1
+}
+
+config_file="$SCRATCH/Ste-JustinePacbioWGS/.myconf.json"
+JASMINE_VERSION="2.0.0"
+while getopts "r:t:c:" opt; do
+    case "${opt}" in
+		r)	run_id="${OPTARG}" ;;
+        t)  JASMINE_VERSION="${OPTARG}" ;;
+        c)  config_file="${OPTARG}" ;;
+        :)  echo "Error: -${OPTARG} requires an argument."; usage ;;
+        *)  usage ;;
+    esac
+done
+
+if [ -z "$run_id" ]; then 
+	usage
+fi
+# default value for config
+if [ ! -f "$config_file" ]; then
+	if [ -f "$(dirname "$0")/.myconf.json" ]; then
+		config_file="$(dirname "$0")/.myconf.json"
+	else
+		echo "config file not found: $config_file. You can input one with option '-c'"
+		exit 1
+	fi
+fi
+
+# run_path in the config points to the folder containing one subfolder per run;
+# the run itself contains one subfolder per well/cell (ie 1_A01, 1_B01...)
+all_runs_folder=$(jq -r '.Paths.run_path' "$config_file")
+run_folder="$all_runs_folder/$run_id"
+if [ ! -d "$run_folder" ]; then
+	echo "Run ID folder was not found in $run_folder"
+	exit 1
+fi
+# Tracks which cell folder maps to which submitted Slurm job ID, for later follow-up
+overall_job_log="$(dirname $0)/jasmine_run_$run_id.log"
+ >"$overall_job_log"
+for cell_folder in "$run_folder"/*/; do
+	echo "Cell folder: $cell_folder"
+	if [ ! -d "$cell_folder/pb_formats" ]; then
+		echo "pb_format folder not found in $cell_folder. Skipping"
+		continue
+	fi
+
+	# jasmine.slurm touches this marker only after it fully succeeds for this version;
+	# skip cells that were already launched and completed successfully.
+	done_marker="$cell_folder/pb_formats/.jasmine_${JASMINE_VERSION}.done"
+	if [ -f "$done_marker" ]; then
+		echo "Cell $cell_folder already completed for jasmine $JASMINE_VERSION. Skipping"
+		continue
+	fi
+
+	# The consensusreadset XML name embeds the well's barcode (bcXXXX); there should be exactly one per well
+	shopt -s nullglob
+	xml_matches=("$cell_folder/pb_formats"/*.hifi_reads.bc[0-9][0-9][0-9][0-9].consensusreadset.xml)
+	shopt -u nullglob
+	if [ "${#xml_matches[@]}" -eq 0 ]; then
+		echo "Error: no hifi_reads consensusreadset XML found in $cell_folder/pb_formats. Skipping"
+		continue
+	fi
+	if [ "${#xml_matches[@]}" -gt 1 ]; then
+		echo "Error: expected exactly one hifi_reads consensusreadset XML in $cell_folder/pb_formats, found ${#xml_matches[@]}: ${xml_matches[*]}. Skipping"
+		continue
+	fi
+	xml_file="${xml_matches[0]}"
+	echo "$xml_file"
+	echo "sbatch -D $cell_folder/pb_formats $(dirname $0)/jasmine.slurm -x $xml_file -t $JASMINE_VERSION -c $config_file"
+	job_id=$(sbatch --parsable -D "$cell_folder/pb_formats" "$(dirname $0)/jasmine.slurm" -x "$xml_file" -t "$JASMINE_VERSION" -c "$config_file")
+	echo "Submitted job $job_id"
+	echo "$cell_folder job id: $job_id" >>"$overall_job_log"
+done
+


### PR DESCRIPTION
Jasmine does the methylation calls for pacbio reads. It is usually done automatically as part of primary analysis on the sequencer itself. However, the jasmine version has a large influence on methylation calls because they can use different models.
For example, the on instrument suite ICSv13.3 introduced for SPRQ chemistry uses jasmine 2.3.0, while
the older ICSv13.1 suite uses jasmine 2.2.1.
SickKids hospital recommends the jasmine v2.0.0 model. The jasmine.slurm script allows a bam with kinetics data to use a different jasmine version specified as argument