### PR TITLE
Fix concordance offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Split the rclone GVCF download out of `Postanalysis/run_concordance.sh` into a new `Postanalysis/fetch_concordance_gvcf.sh`. Job nodes are slow/blocked for that transfer, which made the `sbatch` step take way too long; `postprocessPart1.sh` now runs the fetch synchronously on the login node for each sample (proband/parents) and only submits `run_concordance.sh` via `sbatch` if the download succeeds. `run_concordance.sh` itself now only does the GATK genotyping and SR/LR comparison, and errors out if the GVCF isn't already present.
+- Split the rclone GVCF download out of `Postanalysis/run_concordance.sh` into a new `Postanalysis/fetch_concordance_gvcf.sh`. Job nodes are slow/blocked for that transfer, which made the `sbatch` step take way too long; `postprocessPart1.sh` now runs the fetch synchronously on the login node for each sample (proband/parents) and only submits the sbatch job if the download succeeds. The remaining GATK genotyping and SR/LR comparison logic now only runs as an sbatch job, and errors out if the GVCF isn't already present; to reflect that, the script was renamed `run_concordance.sh` → `run_concordance.slurm`.
 
 ## 2026-08-18: Feat_monitor_benchmark
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
  
 ## [Unreleased]
+## 2026-08-18: Fix-Concordance_offline
+
+### Changed
+
+- Split the rclone GVCF download out of `Postanalysis/run_concordance.sh` into a new `Postanalysis/fetch_concordance_gvcf.sh`. Job nodes are slow/blocked for that transfer, which made the `sbatch` step take way too long; `postprocessPart1.sh` now runs the fetch synchronously on the login node for each sample (proband/parents) and only submits `run_concordance.sh` via `sbatch` if the download succeeds. `run_concordance.sh` itself now only does the GATK genotyping and SR/LR comparison, and errors out if the GVCF isn't already present.
+
 ## 2026-08-18: Feat_monitor_benchmark
 
 ### Added

--- a/Postanalysis/README.md
+++ b/Postanalysis/README.md
@@ -131,7 +131,7 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
 
 - **fetch_concordance_gvcf.sh**
   - *Usage*: `bash Postanalysis/fetch_concordance_gvcf.sh -n <sample_name> -o <output_dir> [-c <config_file>] [-l <log_file>]`
-  - *Goal*: Downloads a sample's Illumina short-read GVCF from the staging server via `rclone`, ahead of `run_concordance.sh`. Split out from `run_concordance.sh` and run directly on the login node (not via `sbatch`) because job nodes can be very slow/blocked for this transfer (or completely impossible on Narval/Rorqual); `postprocessPart1.sh` calls this synchronously for each sample before submitting the `sbatch` job.
+  - *Goal*: Downloads a sample's Illumina short-read GVCF from the staging server via `rclone`, ahead of `run_concordance.slurm`. Split out from `run_concordance.slurm` and run directly on the login node (not via `sbatch`) because job nodes can be very slow/blocked for this transfer (or completely impossible on Narval/Rorqual); `postprocessPart1.sh` calls this synchronously for each sample before submitting the `sbatch` job.
   - *Arguments*:
     - `-n` Sample name — used to locate the GVCF on `staging_juno:/pragmatiq-staging-sd4h/data/<sample_name>/`
     - `-o` Output directory; the GVCF is written under `<output_dir>/Concordance/`
@@ -142,8 +142,8 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
 
 ---
 
-- **run_concordance.sh**
-  - *Usage*: `sbatch Postanalysis/run_concordance.sh -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-f <fasta>] [-t <tools_folder>] [-l <log_file>]`
+- **run_concordance.slurm**
+  - *Usage*: `sbatch Postanalysis/run_concordance.slurm -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-f <fasta>] [-t <tools_folder>] [-l <log_file>]`
   - *Goal*: Verifies that a PacBio long-read VCF and its matching Illumina short-read GVCF originate from the same patient by computing genotype concordance across shared SNV sites (expected ≥ 90 % for same-patient pairs). Also runs a secondary 44-SNP fingerprint check with `bcftools isec` for quick confirmation.
   - *Arguments*:
     - `-n` Sample name — used to locate the already-downloaded GVCF under `<output_dir>/Concordance/`
@@ -173,7 +173,7 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
     - **SAME PATIENT** (≥ 90 % genotype concordance on shared SNVs)
     - **AMBIGUOUS** (75–90 %)
     - **LIKELY DIFFERENT PATIENTS** (< 75 %)
-  - *Notes*: Requires `cyvcf2` and `numpy` (available via the `Tools/ENV` virtualenv). Called automatically by `run_concordance.sh`; can also be run standalone for ad-hoc comparisons.
+  - *Notes*: Requires `cyvcf2` and `numpy` (available via the `Tools/ENV` virtualenv). Called automatically by `run_concordance.slurm`; can also be run standalone for ad-hoc comparisons.
 
 ---
 

--- a/Postanalysis/README.md
+++ b/Postanalysis/README.md
@@ -129,11 +129,24 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
 
 ---
 
+- **fetch_concordance_gvcf.sh**
+  - *Usage*: `bash Postanalysis/fetch_concordance_gvcf.sh -n <sample_name> -o <output_dir> [-c <config_file>] [-l <log_file>]`
+  - *Goal*: Downloads a sample's Illumina short-read GVCF from the staging server via `rclone`, ahead of `run_concordance.sh`. Split out from `run_concordance.sh` and run directly on the login node (not via `sbatch`) because job nodes can be very slow/blocked for this transfer (or completely impossible on Narval/Rorqual); `postprocessPart1.sh` calls this synchronously for each sample before submitting the `sbatch` job.
+  - *Arguments*:
+    - `-n` Sample name — used to locate the GVCF on `staging_juno:/pragmatiq-staging-sd4h/data/<sample_name>/`
+    - `-o` Output directory; the GVCF is written under `<output_dir>/Concordance/`
+    - `-c` Config file (for the `Rclone.short_reads_depot` path)
+    - `-l` Status log file
+  - *Outputs*: `<output_dir>/Concordance/<sample>.dragen.hard-filtered.gvcf.gz` (and its `.tbi` if present remotely).
+  - *Exit codes*: `0` already local or downloaded successfully; `1` download error; `2` GVCF not found on staging (concordance should be skipped for this sample).
+
+---
+
 - **run_concordance.sh**
   - *Usage*: `sbatch Postanalysis/run_concordance.sh -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-f <fasta>] [-t <tools_folder>] [-l <log_file>]`
   - *Goal*: Verifies that a PacBio long-read VCF and its matching Illumina short-read GVCF originate from the same patient by computing genotype concordance across shared SNV sites (expected ≥ 90 % for same-patient pairs). Also runs a secondary 44-SNP fingerprint check with `bcftools isec` for quick confirmation.
   - *Arguments*:
-    - `-n` Sample name — used to locate the GVCF on `staging_juno:/pragmatiq-staging-sd4h/data/<sample_name>/`
+    - `-n` Sample name — used to locate the already-downloaded GVCF under `<output_dir>/Concordance/`
     - `-v` Normalized PacBio SNV VCF (`.vcf.gz`), produced by `postprocessPart1.sh`
     - `-o` Output directory; results are written under `<output_dir>/Concordance/`
     - `-f` Reference FASTA (default: `$SCRATCH/GATK_references/Homo_sapiens_assembly38.fasta`)
@@ -143,7 +156,7 @@ rclone ls staging_juno:/pragmatiq-staging-sd4h/data/[sample_name]
     - `concordance_report_<sample>.txt` — full genotype concordance report from `sr-lr_vcf_concordance.py`
     - `Isec/<sample>_summary.txt` — 44-SNP position summary (number of non-ref variants found)
     - `Isec/<sample>_report.txt` — list of mismatched positions (empty if none)
-  - *Notes*: Downloads the GVCF via `rclone` (requires `staging_juno` remote configured). Converts the GVCF to VCF with GATK `GenotypeGVCFs` before comparison. Skips gracefully if the GVCF is not found on the staging server. The 44-SNP BED file is expected at `$SCRATCH/SNPs44.bed`.
+  - *Notes*: Requires `fetch_concordance_gvcf.sh` to have already downloaded the GVCF into `<output_dir>/Concordance/` — exits with an error otherwise. Converts the GVCF to VCF with GATK `GenotypeGVCFs` before comparison. The 44-SNP BED file is expected at `$SCRATCH/SNPs44.bed`.
 
 ---
 

--- a/Postanalysis/fetch_concordance_gvcf.sh
+++ b/Postanalysis/fetch_concordance_gvcf.sh
@@ -4,8 +4,8 @@
 #
 # This is meant to be run directly on the login node (NOT inside an sbatch job) —
 # job nodes on some clusters have slow or no direct internet/staging access, which
-# made the rclone step inside run_concordance.sh take way too long. Run this first,
-# then submit run_concordance.sh (which now assumes the GVCF is already local) via sbatch.
+# made the rclone step inside run_concordance.slurm take way too long. Run this first,
+# then submit run_concordance.slurm (which now assumes the GVCF is already local) via sbatch.
 #
 # Usage: fetch_concordance_gvcf.sh -n <sample_name> -o <output_dir> [-c <config_file>] [-l <log_file>]
 #   -n  Sample name (used to locate the GVCF on staging_juno)

--- a/Postanalysis/fetch_concordance_gvcf.sh
+++ b/Postanalysis/fetch_concordance_gvcf.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Fetches the Illumina GVCF for a sample from the staging server via rclone.
+#
+# This is meant to be run directly on the login node (NOT inside an sbatch job) —
+# job nodes on some clusters have slow or no direct internet/staging access, which
+# made the rclone step inside run_concordance.sh take way too long. Run this first,
+# then submit run_concordance.sh (which now assumes the GVCF is already local) via sbatch.
+#
+# Usage: fetch_concordance_gvcf.sh -n <sample_name> -o <output_dir> [-c <config_file>] [-l <log_file>]
+#   -n  Sample name (used to locate the GVCF on staging_juno)
+#   -o  Output directory (a Concordance/ subdirectory will be created inside it)
+#   -c  Config file (default: <here_folder>/../.myconf.json)
+#   -l  Log file
+#
+# Exit codes:
+#   0  GVCF/VCF already local, or downloaded successfully
+#   1  Download error
+#   2  GVCF not found on staging server — concordance should be skipped for this sample
+
+set -eo pipefail
+
+usage() {
+    echo "Usage: $0 -n <sample_name> -o <output_dir> [-c <config_file>] [-l <log_file>]"
+    1>&2; exit 1
+}
+
+here_folder="$(cd "$(dirname "$0")" && pwd)"
+sample_name=""
+output_dir=""
+log_file=""
+config_file="$here_folder/../.myconf.json"
+while getopts ":n:o:l:c:" opt; do
+    case "${opt}" in
+        n)  sample_name="${OPTARG}" ;;
+        o)  output_dir="${OPTARG}" ;;
+        l)  log_file="${OPTARG}" ;;
+        c)  config_file="${OPTARG}" ;;
+        :)  echo "Error: -${OPTARG} requires an argument."; usage ;;
+        *)  usage ;;
+    esac
+done
+log_step() { echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"; [ -n "${log_file:-}" ] && echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*" >> "$log_file"; }
+
+if [ -z "$sample_name" ] || [ -z "$output_dir" ]; then
+    echo "Error: -n and -o are required."
+    usage
+fi
+
+REMOTE_BASE_PREFIX=$(jq -r '.Rclone.short_reads_depot' "$config_file")
+
+concordance_dir="$output_dir/Concordance"
+mkdir -p "$concordance_dir"
+
+remote_dir="${REMOTE_BASE_PREFIX}/${sample_name}"
+sr_gvcf_name="${sample_name}.dragen.hard-filtered.gvcf.gz"
+sr_vcf="$concordance_dir/${sample_name}.dragen.hard-filtered.vcf.gz"
+sr_gvcf="${concordance_dir}/${sr_gvcf_name}"
+
+if [ -f "$sr_gvcf" ] || [ -f "$sr_vcf" ]; then
+    echo "${sample_name}: GVCF/VCF already local, skipping download"
+    exit 0
+fi
+
+# ── Locate GVCF on staging server ────────────────────────────────────────────
+echo "Searching for ${sr_gvcf_name} on ${remote_dir} with command:"
+cat << EOF
+rclone lsf --format "tp" --files-only -R --include "$sr_gvcf_name" "$remote_dir"
+EOF
+remote_listing=$(rclone lsf --format "tp" --files-only -R --include "$sr_gvcf_name" "$remote_dir" 2>/dev/null || true)
+
+if [ -z "$remote_listing" ]; then
+    echo "WARNING: ${sr_gvcf_name} not found on staging_juno for sample ${sample_name}. Skipping concordance."
+    log_step "SKIPPED: concordance fetch for ${sample_name} (GVCF not found on staging)"
+    exit 2
+else
+    echo "Found these results:"
+    echo "$remote_listing"
+fi
+
+result_count=$(echo "$remote_listing" | wc -l)
+if [ "$result_count" -gt 1 ]; then
+    echo "Found ${result_count} matches for ${sr_gvcf_name} — selecting the most recent."
+fi
+# Each line is "YYYY-MM-DD HH:MM:SS path"; reverse-sort picks the most recent, awk extracts the path
+remote_result=$(echo "$remote_listing" | sort -r | head -1 | awk -F';' '{print $NF}')
+
+# ── Download GVCF (and index if available) ───────────────────────────────────
+echo "Found: ${remote_result} — downloading to ${concordance_dir}/ with command:"
+cat << EOF
+rclone copy "${remote_dir}/${remote_result}"      "$concordance_dir/"
+EOF
+rclone copy "${remote_dir}/${remote_result}"      "$concordance_dir/"
+rclone copy "${remote_dir}/${remote_result}.tbi"  "$concordance_dir/" 2>/dev/null || true
+
+if [ ! -f "$sr_gvcf" ]; then
+    echo "ERROR: Download of ${sr_gvcf_name} failed."
+    log_step "FAILED: concordance fetch for ${sample_name} (download error)"
+    exit 1
+fi
+
+log_step "SUCCESS: concordance fetch for ${sample_name}"

--- a/Postanalysis/postprocessPart1.sh
+++ b/Postanalysis/postprocessPart1.sh
@@ -200,7 +200,7 @@ function log_step() {
 }
 
 # Fetches the SR GVCF for a sample directly on the login node (rclone is slow/blocked
-# from job nodes), so run_concordance.sh can be submitted via sbatch without waiting on it.
+# from job nodes), so run_concordance.slurm can be submitted via sbatch without waiting on it.
 # Returns 1 (and logs why) if concordance should be skipped for this sample.
 function fetch_concordance() {
 	local sample_name="$1"
@@ -787,7 +787,7 @@ if [[ $group_code != "decode" && ("$include_concordance" == true || "$run_all" =
 
 	if fetch_concordance "$proband_name"; then
 		dependency_concordance_proband="$(sbatch --parsable -J "sr-lr_${family_id}_proband_${proband_name}" \
-			-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
+			-D "$directory/Concordance" "$here_folder/run_concordance.slurm" \
 			-n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
 		echo "Concordance report for proband: $directory/Concordance/concordance_report_${proband_name}.txt" >> "$report_file"
 		log_step "SUBMITTED: concordance_${family_id}_proband (job_id=$dependency_concordance_proband)"
@@ -796,7 +796,7 @@ if [[ $group_code != "decode" && ("$include_concordance" == true || "$run_all" =
 
 	if fetch_concordance "$first_parent_name"; then
 		dependency_concordance_first="$(sbatch --parsable -J "sr-lr_${family_id}_${first_parent_role}_${first_parent_name}" \
-			-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
+			-D "$directory/Concordance" "$here_folder/run_concordance.slurm" \
 			-n "$first_parent_name" -v "$first_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
 		echo "Concordance report for ${first_parent_role}: $directory/Concordance/concordance_report_${first_parent_name}.txt" >> "$report_file"
 		log_step "SUBMITTED: concordance_${family_id}_${first_parent_role} (job_id=$dependency_concordance_first)"
@@ -806,7 +806,7 @@ if [[ $group_code != "decode" && ("$include_concordance" == true || "$run_all" =
 	if [ "$mode" == "trio" ]; then
 		if fetch_concordance "$second_parent_name"; then
 			dependency_concordance_second="$(sbatch --parsable -J "sr-lr_${family_id}_${second_parent_role}_${second_parent_name}" \
-				-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
+				-D "$directory/Concordance" "$here_folder/run_concordance.slurm" \
 				-n "$second_parent_name" -v "$second_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
 			echo "Concordance report for ${second_parent_role}: $directory/Concordance/concordance_report_${second_parent_name}.txt" >> "$report_file"
 			log_step "SUBMITTED: concordance_${family_id}_${second_parent_role} (job_id=$dependency_concordance_second)"

--- a/Postanalysis/postprocessPart1.sh
+++ b/Postanalysis/postprocessPart1.sh
@@ -199,6 +199,24 @@ function log_step() {
 	echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*" | tee -a "$log_file"
 }
 
+# Fetches the SR GVCF for a sample directly on the login node (rclone is slow/blocked
+# from job nodes), so run_concordance.sh can be submitted via sbatch without waiting on it.
+# Returns 1 (and logs why) if concordance should be skipped for this sample.
+function fetch_concordance() {
+	local sample_name="$1"
+	if bash "$here_folder/fetch_concordance_gvcf.sh" -n "$sample_name" -o "$directory" -c "$config_file" -l "$log_file"; then
+		return 0
+	else
+		local rc=$?
+		if [ "$rc" -eq 2 ]; then
+			log_step "SKIPPED: concordance for ${sample_name} (GVCF not found on staging)"
+		else
+			log_step "FAILED: concordance fetch for ${sample_name} (rc=$rc)"
+		fi
+		return 1
+	fi
+}
+
 # send_status.log helpers — static file, stores last known status per step
 function step_done() {
 	grep -q "^${1}: DONE" "$directory/send_status.log" 2>/dev/null
@@ -760,32 +778,40 @@ if [ "$include_multiqc" == true ] || [ "$run_all" == true ]; then
 fi
 
 #SR/LR concordance step
+# Note: the SR GVCF is fetched via rclone directly here (fetch_concordance), not inside the
+# sbatch job — job nodes can be very slow/blocked for that transfer. Only samples whose
+# fetch succeeds get an sbatch job submitted for the GATK genotyping + comparison.
 if [[ $group_code != "decode" && ("$include_concordance" == true || "$run_all" == true) ]] ; then
 	echo "Launching SR/LR concordance checks" >> "$report_file"
 	mkdir -p "$directory/Concordance"
-	cat << EOF 
-"Running the following: sbatch --parsable -J concordance_${family_id}_proband \
--D $directory/Concordance $here_folder/run_concordance.sh \
--n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -f "$fasta_path" -c "$config_file"
-EOF
-	dependency_concordance_proband="$(sbatch --parsable -J "sr-lr_${family_id}_proband_${proband_name}" \
-		-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
-		-n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file" -c "$config_file")"
-	echo "Concordance report for proband: $directory/Concordance/concordance_report_${proband_name}.txt" >> "$report_file"
-	log_step "SUBMITTED: concordance_${family_id}_proband (job_id=$dependency_concordance_proband)"
-	dependency_concordance_first="$(sbatch --parsable -J "sr-lr_${family_id}_${first_parent_role}_${first_parent_name}" \
-		-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
-		-n "$first_parent_name" -v "$first_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file" -c "$config_file")"
-	echo "Concordance report for ${first_parent_role}: $directory/Concordance/concordance_report_${first_parent_name}.txt" >> "$report_file"
-	log_step "SUBMITTED: concordance_${family_id}_${first_parent_role} (job_id=$dependency_concordance_first)"
-	final_dependencies+=("$dependency_concordance_proband" "$dependency_concordance_first")
-	if [ "$mode" == "trio" ]; then
-		dependency_concordance_second="$(sbatch --parsable -J "sr-lr_${family_id}_${second_parent_role}_${second_parent_name}" \
+
+	if fetch_concordance "$proband_name"; then
+		dependency_concordance_proband="$(sbatch --parsable -J "sr-lr_${family_id}_proband_${proband_name}" \
 			-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
-			-n "$second_parent_name" -v "$second_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file" -c "$config_file")"
-		echo "Concordance report for ${second_parent_role}: $directory/Concordance/concordance_report_${second_parent_name}.txt" >> "$report_file"
-		log_step "SUBMITTED: concordance_${family_id}_${second_parent_role} (job_id=$dependency_concordance_second)"
-		final_dependencies+=("$dependency_concordance_second")
+			-n "$proband_name" -v "$proband_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
+		echo "Concordance report for proband: $directory/Concordance/concordance_report_${proband_name}.txt" >> "$report_file"
+		log_step "SUBMITTED: concordance_${family_id}_proband (job_id=$dependency_concordance_proband)"
+		final_dependencies+=("$dependency_concordance_proband")
+	fi
+
+	if fetch_concordance "$first_parent_name"; then
+		dependency_concordance_first="$(sbatch --parsable -J "sr-lr_${family_id}_${first_parent_role}_${first_parent_name}" \
+			-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
+			-n "$first_parent_name" -v "$first_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
+		echo "Concordance report for ${first_parent_role}: $directory/Concordance/concordance_report_${first_parent_name}.txt" >> "$report_file"
+		log_step "SUBMITTED: concordance_${family_id}_${first_parent_role} (job_id=$dependency_concordance_first)"
+		final_dependencies+=("$dependency_concordance_first")
+	fi
+
+	if [ "$mode" == "trio" ]; then
+		if fetch_concordance "$second_parent_name"; then
+			dependency_concordance_second="$(sbatch --parsable -J "sr-lr_${family_id}_${second_parent_role}_${second_parent_name}" \
+				-D "$directory/Concordance" "$here_folder/run_concordance.sh" \
+				-n "$second_parent_name" -v "$second_parent_normalized_SNV" -o "$directory" -t "$tools_folder" -l "$log_file")"
+			echo "Concordance report for ${second_parent_role}: $directory/Concordance/concordance_report_${second_parent_name}.txt" >> "$report_file"
+			log_step "SUBMITTED: concordance_${family_id}_${second_parent_role} (job_id=$dependency_concordance_second)"
+			final_dependencies+=("$dependency_concordance_second")
+		fi
 	fi
 elif [[ $group_code != "decode" ]]; then
 	log_step "SKIPPED: concordance, not for decodeur cases"

--- a/Postanalysis/run_concordance.sh
+++ b/Postanalysis/run_concordance.sh
@@ -6,19 +6,22 @@
 #SBATCH --time=05:00:00
 
 # Runs SR/LR VCF concordance for a single sample.
-# Fetches the Illumina GVCF from the staging server via rclone, then calls
-# sr-lr_vcf_concordance.py with the PacBio normalized SNV VCF and the GVCF.
+# Expects the Illumina GVCF to already be present in <output_dir>/Concordance/ —
+# fetch it first by running fetch_concordance_gvcf.sh directly (not via sbatch),
+# since job nodes can be slow/blocked for the rclone transfer. This script then
+# runs the GATK genotyping and calls sr-lr_vcf_concordance.py with the PacBio
+# normalized SNV VCF and the genotyped GVCF.
 #
-# Usage: run_concordance.sh -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-h <here_folder>] [-c <config_file>]
-#   -n  Sample name (used to locate the GVCF on staging_juno)
+# Usage: run_concordance.sh -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-h <here_folder>]
+#   -n  Sample name (used to locate the already-downloaded GVCF)
 #   -v  Path to the PacBio normalized SNV VCF (from postprocessPart1.sh)
-#   -o  Output directory (a Concordance/ subdirectory will be created inside it)
+#   -o  Output directory (a Concordance/ subdirectory should already exist inside it)
 
 set -eo pipefail
 module load bcftools gatk/4.6.1.0 python/3.11
 
 usage() {
-    echo "Usage: $0 -n <sample_name> -v <lr_snv_vcf> -f -o <output_dir> -t <tools_folder> [-c <config_file>]"
+    echo "Usage: $0 -n <sample_name> -v <lr_snv_vcf> -f -o <output_dir> -t <tools_folder>"
     1>&2; exit 1
 }
 
@@ -29,8 +32,7 @@ lr_vcf=""
 output_dir=""
 fasta="$SCRATCH/GATK_references/Homo_sapiens_assembly38.fasta"
 log_file=""
-config_file="$here_folder/../.myconf.json"
-while getopts ":n:v:o:f:t:l:c:" opt; do
+while getopts ":n:v:o:f:t:l:" opt; do
     case "${opt}" in
         n)  sample_name="${OPTARG}" ;;
         v)  lr_vcf="${OPTARG}" ;;
@@ -40,7 +42,6 @@ while getopts ":n:v:o:f:t:l:c:" opt; do
             here_folder="$tools_folder/../Postanalysis/"
             ;;
         l)  log_file="${OPTARG}" ;;
-        c)  config_file="${OPTARG}" ;;
         :)  echo "Error: -${OPTARG} requires an argument."; usage ;;
         *)  usage ;;
     esac
@@ -63,57 +64,22 @@ if [ ! -f "$fasta" ]; then
     exit 1
 fi
 
-REMOTE_BASE_PREFIX=$(jq -r '.Rclone.short_reads_depot' "$config_file")
-
 concordance_dir="$output_dir/Concordance"
 mkdir -p "$concordance_dir"
 
 report_file="$concordance_dir/concordance_report_${sample_name}.txt"
-remote_dir="${REMOTE_BASE_PREFIX}/${sample_name}"
 sr_gvcf_name="${sample_name}.dragen.hard-filtered.gvcf.gz"
 sr_vcf="$concordance_dir/${sample_name}.dragen.hard-filtered.vcf.gz"
-
-if [ ! -f "$concordance_dir/$sr_gvcf_name" ] && [ ! -f $sr_vcf ]; then
-    # ── Locate GVCF on staging server ────────────────────────────────────────────
-    echo "Searching for ${sr_gvcf_name} on ${remote_dir} with command:"
-    cat << EOF 
-rclone lsf --format "tp" --files-only -R --include "$sr_gvcf_name" "$remote_dir"
-EOF
-    remote_listing=$(rclone lsf --format "tp" --files-only -R --include "$sr_gvcf_name" "$remote_dir" 2>/dev/null || true)
-
-    if [ -z "$remote_listing" ]; then
-        echo "WARNING: ${sr_gvcf_name} not found on staging_juno for sample ${sample_name}. Skipping concordance."
-        exit 0
-    else echo "Found these results:" ; echo "$remote_listing"
-    fi
-
-    result_count=$(echo "$remote_listing" | wc -l)
-    if [ "$result_count" -gt 1 ]; then
-        echo "Found ${result_count} matches for ${sr_gvcf_name} — selecting the most recent."
-    fi
-    # Each line is "YYYY-MM-DD HH:MM:SS path"; reverse-sort picks the most recent, awk extracts the path
-    remote_result=$(echo "$remote_listing" | sort -r | head -1 | awk -F';' '{print $NF}')
-        
-    # ── Download GVCF (and index if available) ───────────────────────────────────
-    echo "Found: ${remote_result} — downloading to ${concordance_dir}/ with command:"
-    cat << EOF
-rclone copy "${remote_dir}/${remote_result}"      "$concordance_dir/"
-EOF
-    rclone copy "${remote_dir}/${remote_result}"      "$concordance_dir/"
-    rclone copy "${remote_dir}/${remote_result}.tbi"  "$concordance_dir/" 2>/dev/null || true
-
-    sr_gvcf="${concordance_dir}/${sr_gvcf_name}"
-
-    if [ ! -f "$sr_gvcf" ]; then
-        echo "ERROR: Download of ${sr_gvcf_name} failed."
-        exit 1
-    fi
-
-else echo "skipping download"
-fi
 sr_gvcf="${concordance_dir}/${sr_gvcf_name}"
+
+if [ ! -f "$sr_gvcf" ] && [ ! -f "$sr_vcf" ]; then
+    echo "ERROR: Neither ${sr_gvcf_name} nor $(basename "$sr_vcf") found in ${concordance_dir}."
+    echo "Run fetch_concordance_gvcf.sh -n \"$sample_name\" -o \"$output_dir\" first to download the short-read GVCF."
+    exit 1
+fi
+
 # Index locally if the remote .tbi was absent
-if [ ! -f "${sr_gvcf}.tbi" ]; then
+if [ -f "$sr_gvcf" ] && [ ! -f "${sr_gvcf}.tbi" ]; then
     echo "Indexing ${sr_gvcf_name}..."
     gatk IndexFeatureFile -I "$sr_gvcf"
 fi
@@ -125,6 +91,7 @@ if [ ! -f $sr_vcf ]; then
         --reference "$fasta"
     echo "Gatk Genotype done for sr_gvcf"
     rm "$sr_gvcf"
+    rm "$sr_gvcf.tbi"
 fi
 #------Set up virtual env ------#
 ENVDIR=$tools_folder/ENV
@@ -154,10 +121,6 @@ EOF
 
     echo "Concordance report written to: ${report_file}"
 fi
-
-
-
-
 
 # Backup report with intervals:
 deactivate

--- a/Postanalysis/run_concordance.slurm
+++ b/Postanalysis/run_concordance.slurm
@@ -12,7 +12,7 @@
 # runs the GATK genotyping and calls sr-lr_vcf_concordance.py with the PacBio
 # normalized SNV VCF and the genotyped GVCF.
 #
-# Usage: run_concordance.sh -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-h <here_folder>]
+# Usage: run_concordance.slurm -n <sample_name> -v <lr_snv_vcf> -o <output_dir> [-h <here_folder>]
 #   -n  Sample name (used to locate the already-downloaded GVCF)
 #   -v  Path to the PacBio normalized SNV VCF (from postprocessPart1.sh)
 #   -o  Output directory (a Concordance/ subdirectory should already exist inside it)


### PR DESCRIPTION
Split the rclone GVCF download out of `Postanalysis/run_concordance.sh` into a new `Postanalysis/fetch_concordance_gvcf.sh`. Job nodes are slow (Fir) or blocked (Narval/Rorqual) for that transfer, which makes the `sbatch run_concordance.sh` step take way too long (sometimes exceeding 6 hours) ; `postprocessPart1.sh` now runs the fetch synchronously on the login node for each sample (proband/parents) and only submits the sbatch job if the download succeeds. The remaining GATK genotyping and SR/LR comparison logic now only runs as an sbatch job, and errors out if the GVCF isn't already present; to reflect that, the script was renamed `run_concordance.sh` → `run_concordance.slurm`.